### PR TITLE
Refactor Pipe to Triple Quote characters for Graql Queries

### DIFF
--- a/behaviour/graql/language/define.feature
+++ b/behaviour/graql/language/define.feature
@@ -37,10 +37,14 @@ Feature: Graql Define Query
 
   Scenario: define a subtype creates a type
     Given graql define
-      """ define dog sub entity; """
+      """
+      define dog sub entity;
+      """
     Given the integrity is validated
     When get answers of graql query
-      """ match $x type dog; get; """
+      """
+      match $x type dog; get;
+      """
     Then answers are labeled
       | x   |
       | dog |
@@ -48,11 +52,15 @@ Feature: Graql Define Query
 
   Scenario: define subtype creates child of supertype
     Given graql define
-      """ define child sub person;  """
+      """
+      define child sub person; 
+      """
     Given the integrity is validated
 
     When get answers of graql query
-      """ match $x sub person; get; """
+      """
+      match $x sub person; get;
+      """
     Then answers are labeled
       | x      |
       | person |
@@ -61,11 +69,15 @@ Feature: Graql Define Query
 
   Scenario: define entity subtype inherits 'plays' from supertypes
     Given graql define
-      """ define child sub person; """
+      """
+      define child sub person;
+      """
     Given the integrity is validated
 
     When get answers of graql query
-      """ match $x plays employee; get; """
+      """
+      match $x plays employee; get;
+      """
 
     Then answers are labeled
       | x      |
@@ -75,11 +87,15 @@ Feature: Graql Define Query
 
   Scenario: define entity subtype inherits 'has' from supertypes
     Given graql define
-      """ define child sub person; """
+      """
+      define child sub person;
+      """
     Given the integrity is validated
 
     When get answers of graql query
-      """ match $x has name; get; """
+      """
+      match $x has name; get;
+      """
 
     Then answers are labeled
       | x      |
@@ -89,11 +105,15 @@ Feature: Graql Define Query
 
   Scenario: define entity inherits 'key' from supertypes
     Given graql define
-      """ define child sub person; """
+      """
+      define child sub person;
+      """
     Given the integrity is validated
 
     When get answers of graql query
-      """ match $x key email; get; """
+      """
+      match $x key email; get;
+      """
 
     Then answers are labeled
       | x      |
@@ -105,11 +125,15 @@ Feature: Graql Define Query
   # re-enable when 'relates' is inherited
   Scenario: define relation subtype inherits 'relates' from supertypes without role subtyping
     Given graql define
-      """ define part-time-employment sub employment; """
+      """
+      define part-time-employment sub employment;
+      """
     Given the integrity is validated
 
     When get answers of graql query
-      """ match $x relates employee; get; """
+      """
+      match $x relates employee; get;
+      """
 
     Then answers are labeled
       | x                    |
@@ -121,11 +145,15 @@ Feature: Graql Define Query
   # re-enable when 'relates' is bound to a relation and blockable
   Scenario: define relation subtype with role subtyping blocks parent role
     Given graql define
-      """ define part-time-employment sub employment, relates part-timer as employee; """
+      """
+      define part-time-employment sub employment, relates part-timer as employee;
+      """
     Given the integrity is validated
 
     When get answers of graql query
-      """ match $x relates employee; get; """
+      """
+      match $x relates employee; get;
+      """
     Then answers are labeled
       | x                    |
       | employment           |
@@ -144,11 +172,15 @@ Feature: Graql Define Query
 
   Scenario: define attribute subtype has same datatype as supertype
     Given graql define
-      """ define first-name sub name; """
+      """
+      define first-name sub name;
+      """
     Given the integrity is validated
 
     When get answers of graql query
-      """ match $x datatype string; get; """
+      """
+      match $x datatype string; get;
+      """
     Then answers are labeled
       | x          |
       | name       |
@@ -163,7 +195,9 @@ Feature: Graql Define Query
 
   Scenario: define additional 'plays' is visible from all children
     Given graql define
-      """ define employment sub relation, relates employer; """
+      """
+      define employment sub relation, relates employer;
+      """
     Given the integrity is validated
 
     Given graql define
@@ -175,7 +209,9 @@ Feature: Graql Define Query
     Given the integrity is validated
 
     When get answers of graql query
-      """ match $x type child, plays $r; get; """
+      """
+      match $x type child, plays $r; get;
+      """
 
     Then answers are labeled
       | x      | r                |
@@ -198,7 +234,9 @@ Feature: Graql Define Query
     Given the integrity is validated
 
     When get answers of graql query
-      """ match $x type child, has $y; get; """
+      """
+      match $x type child, has $y; get;
+      """
 
     Then answers are labeled
       | x      | y            |
@@ -219,7 +257,9 @@ Feature: Graql Define Query
     Given the integrity is validated
 
     When get answers of graql query
-      """ match $x type child, key $y; get; """
+      """
+      match $x type child, key $y; get;
+      """
 
     Then answers are labeled
       | x      | y      |
@@ -239,7 +279,9 @@ Feature: Graql Define Query
     Given the integrity is validated
 
     When get answers of graql query
-      """ match $x type part-time-employment, relates $r; get; """
+      """
+      match $x type part-time-employment, relates $r; get;
+      """
 
     Then answers are labeled
       | x                     | r          |
@@ -261,7 +303,9 @@ Feature: Graql Define Query
 
   Scenario: define an attribute key- and owner-ship creates the implicit attribute key/ownership relation types
     When get answers of graql query
-      """ match $x sub relation; get;  """
+      """
+      match $x sub relation; get; 
+      """
     Then answers are labeled
       | x              |
       | relation       |
@@ -274,11 +318,15 @@ Feature: Graql Define Query
 
   Scenario: implicit attribute ownerships exist in a hierarchy matching attribute hierarchy
     Given graql define
-      """ define first-name sub name; person sub entity, has first-name; """
+      """
+      define first-name sub name; person sub entity, has first-name;
+      """
     Given the integrity is validated
 
     When get answers of graql query
-      """ match $child sub $super; $super sub @has-attribute; get;  """
+      """
+      match $child sub $super; $super sub @has-attribute; get; 
+      """
     Then answers are labeled
       | child           | super            |
       | @has-attribute  | @has-attribute   |

--- a/behaviour/graql/language/insert.feature
+++ b/behaviour/graql/language/insert.feature
@@ -52,7 +52,9 @@ Feature: Graql Insert Query
     When the integrity is validated
 
     Then get answers of graql query
-      """ match $x isa thing; get; """
+      """
+      match $x isa thing; get;
+      """
     Then answer size is: 4
 
 
@@ -75,13 +77,19 @@ Feature: Graql Insert Query
     Given the integrity is validated
 
     When graql insert
-      """ insert $p isa person, has ref 0; $r (employee: $p) isa employment, has ref 1; """
+      """
+      insert $p isa person, has ref 0; $r (employee: $p) isa employment, has ref 1;
+      """
     When graql insert
-      """ match $r isa employment; insert $r (employer: $c) isa employment; $c isa company, has ref 2; """
+      """
+      match $r isa employment; insert $r (employer: $c) isa employment; $c isa company, has ref 2;
+      """
     When the integrity is validated
 
     Then get answers of graql query
-      """ match $r (employer: $c, employee: $p) isa employment; get; """
+      """
+      match $r (employer: $c, employee: $p) isa employment; get;
+      """
     Then answer concepts all have key: ref
     Then answer keys are
       | p    | c    | r    |
@@ -99,11 +107,15 @@ Feature: Graql Insert Query
     Given the integrity is validated
 
     When graql insert
-      """ insert $n "John" isa name, has ref 0; """
+      """
+      insert $n "John" isa name, has ref 0;
+      """
     When the integrity is validated
 
     Then get answers of graql query
-      """ match $a "John"; get; """
+      """
+      match $a "John"; get;
+      """
     Then answer concepts all have key: ref
     Then answer keys are
       | a    |
@@ -122,11 +134,15 @@ Feature: Graql Insert Query
     Given the integrity is validated
 
     When graql insert
-      """ insert $a "john" isa name, has ref 0; """
+      """
+      insert $a "john" isa name, has ref 0;
+      """
     When the integrity is validated
 
     Then graql insert throws
-      """ insert $a "john" isa name, has ref 1; """
+      """
+      insert $a "john" isa name, has ref 1;
+      """
 
 
   Scenario: insert two owners of the same attribute links owners via attribute
@@ -140,11 +156,15 @@ Feature: Graql Insert Query
     Given the integrity is validated
 
     When graql insert
-      """ insert $p isa person, has age 10, has ref 0; """
+      """
+      insert $p isa person, has age 10, has ref 0;
+      """
     When the integrity is validated
 
     When graql insert
-      """ insert $p isa person, has age 10, has ref 1; """
+      """
+      insert $p isa person, has age 10, has ref 1;
+      """
     When the integrity is validated
 
     Then get answers of graql query

--- a/behaviour/graql/language/match.feature
+++ b/behaviour/graql/language/match.feature
@@ -56,7 +56,9 @@ Feature: Graql Match Clause
     When the integrity is validated
 
     Then get answers of graql query
-      """ match $x isa person; $r (employee: $x) isa relation; get; """
+      """
+      match $x isa person; $r (employee: $x) isa relation; get;
+      """
     Then answer concepts all have key: ref
     Then answer keys are
       | x    | r    |
@@ -98,7 +100,9 @@ Feature: Graql Match Clause
     When the integrity is validated
 
     Then get answers of graql query
-      """ match $r ($x, $y) isa employment; get;  """
+      """
+      match $r ($x, $y) isa employment; get; 
+      """
     Then answer concepts all have key: ref
     Then answer keys are
       | x    | y    | r    |
@@ -124,6 +128,10 @@ Feature: Graql Match Clause
     Given the integrity is validated
 
     When get answers of graql query
-      """ match $x sub $y; $y sub $z; get; """
+      """
+      match $x sub $y; $y sub $z; get;
+      """
     Then each answer satisfies
-      """ match $x sub $z; $x id <answer.x.id>; $z id <answer.z.id>; get; """
+      """
+      match $x sub $z; $x id <answer.x.id>; $z id <answer.z.id>; get;
+      """

--- a/behaviour/graql/language/undefine.feature
+++ b/behaviour/graql/language/undefine.feature
@@ -36,10 +36,14 @@ Feature: Graql Undefine Query
 
   Scenario: undefine a subtype removes a type
     Given graql undefine
-      """ undefine email sub attribute; """
+      """
+      undefine email sub attribute;
+      """
     Given the integrity is validated
     When get answers of graql query
-      """ match $x sub attribute; get;  """
+      """
+      match $x sub attribute; get; 
+      """
     Then answers are labeled
       | x         |
       | attribute |
@@ -48,12 +52,18 @@ Feature: Graql Undefine Query
 
   Scenario: undefine 'plays' from super entity removes 'plays' from subtypes
     Given graql define
-      """ define child sub person;  """
+      """
+      define child sub person; 
+      """
     Given graql undefine
-      """ undefine person plays employee; """
+      """
+      undefine person plays employee;
+      """
     Then the integrity is validated
     When get answers of graql query
-      """ match $x type child; $x plays $role; get;  """
+      """
+      match $x type child; $x plays $role; get; 
+      """
     Then answers are labeled
       | x     | role             |
       | child | @has-name-owner  |
@@ -70,15 +80,21 @@ Feature: Graql Undefine Query
       person has first-name;
       """
     When get answers of graql query
-      """ match $x sub @has-name; get; """
+      """
+      match $x sub @has-name; get;
+      """
     When answers are labeled
       | x               |
       | @has-name       |
       | @has-first-name |
     Then graql undefine
-      """ undefine first-name sub name; """
+      """
+      undefine first-name sub name;
+      """
     Then get answers of graql query
-      """ match $x sub @has-name; get;  """
+      """
+      match $x sub @has-name; get; 
+      """
     When answers are labeled
       | x         |
       | @has-name |
@@ -94,12 +110,18 @@ Feature: Graql Undefine Query
   # re-enable when can query by has $x
   Scenario: undefine 'has' from super entity removes 'has' from child entity
     Given graql define
-      """ define child sub person;  """
+      """
+      define child sub person; 
+      """
     Given graql undefine
-      """ undefine person has name; """
+      """
+      undefine person has name;
+      """
     Then the integrity is validated
     When get answers of graql query
-      """ match $x type child; $x has $attribute; get;  """
+      """
+      match $x type child; $x has $attribute; get; 
+      """
     Then answers are labeled
       | x     | attribute |
       | child | email     |
@@ -107,24 +129,36 @@ Feature: Graql Undefine Query
 
   Scenario: undefine 'key' from super entity removes 'key' from child entity
     Given graql define
-      """ define child sub person;  """
+      """
+      define child sub person; 
+      """
     Given graql undefine
-      """ undefine person key email; """
+      """
+      undefine person key email;
+      """
     Then the integrity is validated
     When get answers of graql query
-      """ match $x type child; $x key email; get; """
+      """
+      match $x type child; $x key email; get;
+      """
     Then answer size is: 0
 
   @ignore
   # re-enable when 'relates' is inherited
   Scenario: undefine 'relates' from super relation removes 'relates' from child relation
     Given graql define
-      """ define part-time sub employment;  """
+      """
+      define part-time sub employment; 
+      """
     Given graql undefine
-      """ undefine employment relates employer; """
+      """
+      undefine employment relates employer;
+      """
     Then the integrity is validated
     When get answers of graql query
-      """ match $x type part-time; $x relates $role; get;  """
+      """
+      match $x type part-time; $x relates $role; get; 
+      """
     Then answers are labeled
       | x         | role     |
       | part-time | employee |
@@ -152,10 +186,14 @@ Feature: Graql Undefine Query
   # TODO fails since undefining an abstract removes the type fully
   Scenario: undefine a type as abstract converts an abstract to concrete type and can create instances
     Given graql undefine
-      """ undefine abstract-type abstract; """
+      """
+      undefine abstract-type abstract;
+      """
     Given the integrity is validated
     When get answers of graql query
-      """ match $x abstract; get;  """
+      """
+      match $x abstract; get; 
+      """
     Then answers are labeled
       | x         |
       | entity    |
@@ -168,21 +206,31 @@ Feature: Graql Undefine Query
   # TODO fails same as undefine abstract; then require sub-abstract type validation
   Scenario: undefine a type as abstract errors if has abstract child types (?)
     Given graql define
-      """ define sub-abstract-type sub abstract-type, abstract; """
+      """
+      define sub-abstract-type sub abstract-type, abstract;
+      """
     Given the integrity is validated
     Then graql undefine throws
-      """ undefine abstract-type abstract; """
+      """
+      undefine abstract-type abstract;
+      """
 
 
   Scenario: undefine a regex on an attribute type, removes regex constraints on attribute
     Given graql undefine
-      """ undefine email regex ".+@\w.com";    """
+      """
+      undefine email regex ".+@\w.com";   
+      """
     Given the integrity is validated
     When graql insert
-      """ insert $x "not-email-regex" isa email;  """
+      """
+      insert $x "not-email-regex" isa email; 
+      """
     Given the integrity is validated
     Then get answers of graql query
-      """ match $x isa email; get; """
+      """
+      match $x isa email; get;
+      """
     Then answer size is: 1
 
 
@@ -198,20 +246,30 @@ Feature: Graql Undefine Query
       """
     Given the integrity is validated
     When get answers of graql query
-      """ match $x sub rule; get; """
+      """
+      match $x sub rule; get;
+      """
     When answers are labeled
       | x     |
       | rule  |
       | arule |
     Then graql undefine
-      """ undefine arule sub rule;  """
+      """
+      undefine arule sub rule; 
+      """
     Then get answers of graql query
-      """ match $x sub rule; get;   """
+      """
+      match $x sub rule; get;  
+      """
     Then answer size is: 1
 
 
   Scenario: undefine a supertype errors if subtypes exist
     Given graql define
-      """ define child sub person;   """
+      """
+      define child sub person;  
+      """
     Then graql undefine throws
-      """ undefine person sub entity; """
+      """
+      undefine person sub entity;
+      """


### PR DESCRIPTION
Currently, we use | |  for multiline queries, which are joined together in the corresponding Graql step BDD implementation. The issue with this is that the UX from the user side seems like multiple queries can actually be written over multiple lines as well.

However, docstrings can be used for this particular data input as well:
"""
asdfasf
"""

Note that the triple quotes must be on their own lines.
This format ensures that only 1 query can be written in all the places queries are currently used as step arguments.