### PR TITLE
Remove all usages of implicit concepts

### DIFF
--- a/behaviour/graql/language/define.feature
+++ b/behaviour/graql/language/define.feature
@@ -248,8 +248,6 @@ Feature: Graql Define Query
       |             | check | value            |
       | EMPLOYEE    | label | employee         |
       | EMPLOYER    | label | employer         |
-      | NAME_OWNER  | label | @has-name-owner  |
-      | EMAIL_OWNER | label | @key-email-owner |
       | CHILD       | label | child            |
     Then uniquely identify answer concepts
       | x     | r           |
@@ -347,55 +345,6 @@ Feature: Graql Define Query
   Scenario: define a rule creates a rule (?)
 
   Scenario: define a sub-role using 'as' is visible from children (?)
-
-
-  Scenario: define an attribute key- and owner-ship creates the implicit attribute key/ownership relation types
-    When get answers of graql query
-      """
-      match $x sub relation; get; 
-      """
-    Then concept identifiers are
-      |           | check | value          |
-      | REL       | label | relation       |
-      | EMP       | label | employment     |
-      | HAS_ATTR  | label | @has-attribute |
-      | HAS_NAME  | label | @has-name      |
-      | KEY_ATTR  | label | @key-attribute |
-      | KEY_EMAIL | label | @key-email     |
-    Then uniquely identify answer concepts
-      | x         |
-      | REL       |
-      | EMP       |
-      | HAS_ATTR  |
-      | HAS_NAME  |
-      | KEY_ATTR  |
-      | KEY_EMAIL |
-
-
-  Scenario: implicit attribute ownerships exist in a hierarchy matching attribute hierarchy
-    Given graql define
-      """
-      define first-name sub name; person sub entity, has first-name;
-      """
-    Given the integrity is validated
-
-    When get answers of graql query
-      """
-      match $child sub $super; $super sub @has-attribute; get; 
-      """
-    Then concept identifiers are
-      |        | check | value           |
-      | ATTR   | label | @has-attribute  |
-      | NAME   | label | @has-name       |
-      | F_NAME | label | @has-first-name |
-    Then uniquely identify answer concepts
-      | child  | super  |
-      | ATTR   | ATTR   |
-      | NAME   | ATTR   |
-      | F_NAME | ATTR   |
-      | NAME   | NAME   |
-      | F_NAME | NAME   |
-      | F_NAME | F_NAME |
 
   Scenario: define a relation with no related roles throws on commit
 

--- a/behaviour/graql/language/define.feature
+++ b/behaviour/graql/language/define.feature
@@ -253,8 +253,6 @@ Feature: Graql Define Query
       | x     | r           |
       | CHILD | EMPLOYEE    |
       | CHILD | EMPLOYER    |
-      | CHILD | NAME_OWNER  |
-      | CHILD | EMAIL_OWNER |
 
 
   @ignore

--- a/behaviour/graql/language/insert.feature
+++ b/behaviour/graql/language/insert.feature
@@ -44,7 +44,7 @@ Feature: Graql Insert Query
     When graql insert
       """
       insert
-        $x isa person, has name $a via $imp;
+        $x isa person, has name $a;
         $r (employee: $x) isa employment;
         $a "John" isa name;
       """
@@ -54,7 +54,7 @@ Feature: Graql Insert Query
       """
       match $x isa thing; get;
       """
-    Then answer size is: 4
+    Then answer size is: 3
 
 
   Scenario: insert an additional role player is visible in the relation

--- a/behaviour/graql/language/undefine.feature
+++ b/behaviour/graql/language/undefine.feature
@@ -68,49 +68,7 @@ Feature: Graql Undefine Query
       """
       match $x type child; $x plays $role; get; 
       """
-    Then concept identifiers are
-      |             | check | value            |
-      | NAME_OWNER  | label | @has-name-owner  |
-      | EMAIL_OWNER | label | @key-email-owner |
-      | CHILD       | label | child            |
-    Then uniquely identify answer concepts
-      | x     | role        |
-      | CHILD | NAME_OWNER  |
-      | CHILD | EMAIL_OWNER |
-
-
-  @ignore
-  # TODO readd when behaves correctly
-  Scenario: undefine an attribute subtype removes implicit ownership relation from hierarchy
-    Given graql define
-      """
-      define
-      first-name sub name;
-      person has first-name;
-      """
-    When get answers of graql query
-      """
-      match $x sub @has-name; get;
-      """
-    When uniquely identify answer concepts
-      | x               |
-      | @has-name       |
-      | @has-first-name |
-    Then graql undefine
-      """
-      undefine first-name sub name;
-      """
-    Then get answers of graql query
-      """
-      match $x sub @has-name; get; 
-      """
-    Then concept identifiers are
-      |          | check | value     |
-      | HAS_NAME | label | @has-name |
-    When uniquely identify answer concepts
-      | x        |
-      | HAS_NAME |
-
+    Then answer size is: 0
 
 
   # TODO is this expected to hold?

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -32,5 +32,5 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/flyingsilverfin/grakn",
-        commit = "03eba7eaf1ac0c5859ca649b4e0e94542867226b",
+        commit = "73262f544f27c06dc1f5de022a6e50e43360da10",
     )

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -32,5 +32,5 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/flyingsilverfin/grakn",
-        commit = "b3e8038cb8fb9d65e1eae14478ff745dfd406e37",
+        commit = "03eba7eaf1ac0c5859ca649b4e0e94542867226b",
     )

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -17,20 +17,20 @@ def graknlabs_common():
 def graknlabs_graql():
     git_repository(
         name = "graknlabs_graql",
-        remote = "https://github.com/graknlabs/graql",
-        commit = "1c573108b3ab8505ab0168f146071fe032d62a61",
+        remote = "https://github.com/flyingsilverfin/graql",
+        commit = "4a18ef735004c1a7c82c6dddff5cc79dfd557070",
     )
 
 def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
-        remote = "https://github.com/graknlabs/client-java",
-        commit = "18c4f726ce7b32ae1b9c151794d1eed937898e23",
+        remote = "https://github.com/flyingsilverfin/client-java",
+        commit = "232fa6085fca01b7c96f4efdcfbe56a8be0c1a88",
     )
 
 def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
-        remote = "https://github.com/graknlabs/grakn",
-        commit = "a950ed90cac3e4cbd1d338b13f7f33e5a6616a35",
+        remote = "https://github.com/flyingsilverfin/grakn",
+        commit = "b3e8038cb8fb9d65e1eae14478ff745dfd406e37",
     )

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -25,12 +25,12 @@ def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
         remote = "https://github.com/flyingsilverfin/client-java",
-        commit = "232fa6085fca01b7c96f4efdcfbe56a8be0c1a88",
+        commit = "a6187f647768f37959a336d619c9e72e7f7cac1d",
     )
 
 def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/flyingsilverfin/grakn",
-        commit = "73262f544f27c06dc1f5de022a6e50e43360da10",
+        commit = "a36ee2649cbb172e7eadcb4015cbbf6fdadfc67a",
     )


### PR DESCRIPTION
According to https://github.com/graknlabs/grakn/issues/5614, we aim to remove implicit relations from Grakn. This means usages in `verification` referring to implicit relations or roles need to be modified or removed.