### PR TITLE
Remove newline in insert feature file

### DIFF
--- a/behaviour/graql/language/insert.feature
+++ b/behaviour/graql/language/insert.feature
@@ -260,7 +260,6 @@ Feature: Graql Insert Query
 
   Scenario: extend relation with duplicate role player
 
-
   Scenario: inserting duplicate keys throws on commit (? or at insert)
 
   Scenario: inserting disallowed role being played throws on commit (? or at insert)


### PR DESCRIPTION
We found an formatting error in the `insert.feature` file.

This PR updates the formatting.