### PR TITLE
Add axiomatic 'define' tests

### DIFF
--- a/behaviour/graql/language/define.feature
+++ b/behaviour/graql/language/define.feature
@@ -26,15 +26,24 @@ Feature: Graql Define Query
     Given graql define
       """
       define
-      person sub entity, plays employee, has name, key email;
-      employment sub relation, relates employee;
+      person sub entity, plays employee, plays earner, has name, key email;
+      employment sub relation, relates employee, plays source-of-income, has start-date, key employment-reference-code;
+      income sub relation, relates earner, relates source-of-income;
+
       name sub attribute, value string;
       email sub attribute, value string;
+      start-date sub attribute, value date;
+      employment-reference-code sub attribute, value string;
       """
     Given the integrity is validated
 
 
-  Scenario: define a subtype creates a type
+  ############
+  # ENTITIES #
+  ############
+
+
+  Scenario: define entity type creates a type
     Given graql define
       """
       define dog sub entity;
@@ -52,7 +61,7 @@ Feature: Graql Define Query
       | DOG |
 
 
-  Scenario: define subtype creates child of supertype
+  Scenario: define entity subtype creates child of its parent type
     Given graql define
       """
       define child sub person; 
@@ -73,7 +82,7 @@ Feature: Graql Define Query
       | CHD |
 
 
-  Scenario: define entity subtype inherits 'plays' from supertypes
+  Scenario: define entity subtype inherits 'plays' from its parent type
     Given graql define
       """
       define child sub person;
@@ -94,7 +103,35 @@ Feature: Graql Define Query
       | CHD |
 
 
-  Scenario: define entity subtype inherits 'has' from supertypes
+  Scenario: define entity subtype inherits 'plays' from all of its supertypes
+    Given graql define
+      """
+      define
+      athlete sub person;
+      runner sub athlete;
+      sprinter sub runner;
+      """
+    Given the integrity is validated
+
+    When get answers of graql query
+      """
+      match $x plays employee; get;
+      """
+    Then concept identifiers are
+      |     | check | value    |
+      | PER | label | person   |
+      | ATH | label | athlete  |
+      | RUN | label | runner   |
+      | SPR | label | sprinter |
+    Then uniquely identify answer concepts
+      | x   |
+      | PER |
+      | ATH |
+      | RUN |
+      | SPR |
+
+
+  Scenario: define entity subtype inherits 'has' from its parent type
     Given graql define
       """
       define child sub person;
@@ -115,7 +152,35 @@ Feature: Graql Define Query
       | CHD |
 
 
-  Scenario: define entity inherits 'key' from supertypes
+  Scenario: define entity subtype inherits 'has' from all of its supertypes
+    Given graql define
+      """
+      define
+      athlete sub person;
+      runner sub athlete;
+      sprinter sub runner;
+      """
+    Given the integrity is validated
+
+    When get answers of graql query
+      """
+      match $x has name; get;
+      """
+    Then concept identifiers are
+      |     | check | value    |
+      | PER | label | person   |
+      | ATH | label | athlete  |
+      | RUN | label | runner   |
+      | SPR | label | sprinter |
+    Then uniquely identify answer concepts
+      | x   |
+      | PER |
+      | ATH |
+      | RUN |
+      | SPR |
+
+
+  Scenario: define entity subtype inherits 'key' from its parent type
     Given graql define
       """
       define child sub person;
@@ -137,92 +202,96 @@ Feature: Graql Define Query
       | CHD |
 
 
-  @ignore
-  # re-enable when 'relates' is inherited
-  Scenario: define relation subtype inherits 'relates' from supertypes without role subtyping
+  Scenario: define entity subtype inherits 'key' from all of its supertypes
     Given graql define
       """
-      define part-time-employment sub employment;
+      define
+      athlete sub person;
+      runner sub athlete;
+      sprinter sub runner;
       """
     Given the integrity is validated
 
     When get answers of graql query
       """
-      match $x relates employee; get;
+      match $x key email; get;
       """
     Then concept identifiers are
-      |     | check | value                |
-      | EMP | label | employment           |
-      | PTT | label | part-time-employment |
+      |     | check | value    |
+      | PER | label | person   |
+      | ATH | label | athlete  |
+      | RUN | label | runner   |
+      | SPR | label | sprinter |
     Then uniquely identify answer concepts
       | x   |
-      | EMP |
-      | PTT |
+      | PER |
+      | ATH |
+      | RUN |
+      | SPR |
 
 
-  @ignore
-  # re-enable when 'relates' is bound to a relation and blockable
-  Scenario: define relation subtype with role subtyping blocks parent role
+  Scenario: define abstract entity type creates a type
     Given graql define
       """
-      define part-time-employment sub employment, relates part-timer as employee;
+      define animal sub entity, abstract;
       """
     Given the integrity is validated
-
     When get answers of graql query
       """
-      match $x relates employee; get;
+      match $x type animal; get;
       """
     Then concept identifiers are
-      |     | check | value                |
-      | EMP | label | employment           |
-      | PTT | label | part-time-employment |
+      |     | check | value  |
+      | ANI | label | animal |
     Then uniquely identify answer concepts
       | x   |
-      | EMP |
-      | PTT |
-
-    # TODO - should employee role be retrieving part-timer as well?
-
-    # Then query 1 has 2 answers
-    # And answers of query 1 satisfy: match $x sub employment; get;
+      | ANI |
 
 
-  Scenario: define relation subtype inherits 'plays' from supertypes
-
-  Scenario: define relation subtype inherits 'has' from supertypes
-
-  Scenario: define relation subtype inherits 'key' from supertypes
-
-
-  Scenario: define attribute subtype has same value as supertype
+  Scenario: define concrete subtype of abstract entity creates child of its parent type
     Given graql define
       """
-      define first-name sub name;
+      define
+      animal sub entity, abstract;
+      horse sub animal;
       """
     Given the integrity is validated
 
     When get answers of graql query
       """
-      match $x value string; get;
+      match $x sub animal; get;
       """
     Then concept identifiers are
-      |        | check | value      |
-      | NAME   | label | name       |
-      | F_NAME | label | first-name |
-      | EMAIL  | label | email      |
+      |     | check | value  |
+      | ANI | label | animal |
+      | HOR | label | horse  |
     Then uniquely identify answer concepts
-      | x      |
-      | NAME   |
-      | F_NAME |
-      | EMAIL  |
+      | x   |
+      | ANI |
+      | HOR |
 
 
-  Scenario: define attribute subtype inherits 'plays' from supertypes
+  Scenario: define abstract subtype of abstract entity creates child of its parent type
+    Given graql define
+      """
+      define
+      animal sub entity, abstract;
+      fish sub animal, abstract;
+      """
+    Given the integrity is validated
 
-  Scenario: define attribute subtype inherits 'has' from supertypes
-
-  Scenario: define attribute subtype inherits 'key' from supertypes
+    When get answers of graql query
+      """
+      match $x sub animal; get;
+      """
+    Then concept identifiers are
+      |     | check | value  |
+      | ANI | label | animal |
+      | FSH | label | fish   |
+    Then uniquely identify answer concepts
+      | x   |
+      | ANI |
+      | FSH |
 
 
   Scenario: define additional 'plays' is visible from all children
@@ -248,6 +317,7 @@ Feature: Graql Define Query
       |             | check | value            |
       | EMPLOYEE    | label | employee         |
       | EMPLOYER    | label | employer         |
+      | EARNER      | label | earner           |
       | NAME_OWNER  | label | @has-name-owner  |
       | EMAIL_OWNER | label | @key-email-owner |
       | CHILD       | label | child            |
@@ -255,6 +325,7 @@ Feature: Graql Define Query
       | x     | r           |
       | CHILD | EMPLOYEE    |
       | CHILD | EMPLOYER    |
+      | CHILD | EARNER      |
       | CHILD | NAME_OWNER  |
       | CHILD | EMAIL_OWNER |
 
@@ -312,6 +383,337 @@ Feature: Graql Define Query
       | CHILD | EMAIL |
 
 
+  #############
+  # RELATIONS #
+  #############
+
+
+  Scenario: define relation type creates a type
+    Given graql define
+      """
+      define pet-ownership sub relation, relates pet-owner, relates owned-pet;
+      """
+    Given the integrity is validated
+    When get answers of graql query
+      """
+      match $x type pet-ownership; get;
+      """
+    Then concept identifiers are
+      |     | check | value         |
+      | POW | label | pet-ownership |
+    Then uniquely identify answer concepts
+      | x   |
+      | POW |
+
+
+  Scenario: define relation subtype creates child of its parent type
+    Given graql define
+      """
+      define fun-employment sub employment, relates employee-having-fun as employee;
+      """
+    Given the integrity is validated
+
+    When get answers of graql query
+      """
+      match $x sub employment; get;
+      """
+    Then concept identifiers are
+      |     | check | value          |
+      | EMP | label | employment     |
+      | FUN | label | fun-employment |
+    Then uniquely identify answer concepts
+      | x   |
+      | EMP |
+      | FUN |
+
+
+  Scenario: define relation type throws if it has no roleplayers and is not marked as abstract
+    Then graql define throws
+      """
+      define useless-relation sub relation;
+      """
+
+
+  @ignore
+  # re-enable when 'relates' is inherited
+  Scenario: define relation subtype inherits 'relates' from supertypes without role subtyping
+    Given graql define
+      """
+      define part-time-employment sub employment;
+      """
+    Given the integrity is validated
+
+    When get answers of graql query
+      """
+      match $x relates employee; get;
+      """
+    Then concept identifiers are
+      |     | check | value                |
+      | EMP | label | employment           |
+      | PTT | label | part-time-employment |
+    Then uniquely identify answer concepts
+      | x   |
+      | EMP |
+      | PTT |
+
+
+  @ignore
+  # re-enable when 'relates' is bound to a relation and blockable
+  Scenario: define relation subtype with role subtyping blocks parent role
+    Given graql define
+      """
+      define part-time-employment sub employment, relates part-timer as employee;
+      """
+    Given the integrity is validated
+
+    When get answers of graql query
+      """
+      match $x relates employee; get;
+      """
+    Then concept identifiers are
+      |     | check | value                |
+      | EMP | label | employment           |
+      | PTT | label | part-time-employment |
+    Then uniquely identify answer concepts
+      | x   |
+      | EMP |
+      | PTT |
+
+    # TODO - should employee role be retrieving part-timer as well?
+
+    # Then query 1 has 2 answers
+    # And answers of query 1 satisfy: match $x sub employment; get;
+
+
+  Scenario: define relation subtype inherits 'plays' from its parent type
+    Given graql define
+      """
+      define contract-employment sub employment, relates contractor as employee;
+      """
+    Given the integrity is validated
+
+    When get answers of graql query
+      """
+      match $x plays source-of-income; get;
+      """
+    Then concept identifiers are
+      |     | check | value               |
+      | EMP | label | employment          |
+      | CEM | label | contract-employment |
+    Then uniquely identify answer concepts
+      | x   |
+      | EMP |
+      | CEM |
+
+
+  Scenario: define relation subtype inherits 'plays' from all of its supertypes
+    Given graql define
+      """
+      define
+      transport-employment sub employment, relates transport-worker as employee;
+      aviation-employment sub transport-employment, relates aviation-worker as transport-worker;
+      flight-attendant-employment sub aviation-employment, relates flight-attendant as aviation-worker;
+      """
+    Given the integrity is validated
+
+    When get answers of graql query
+      """
+      match $x plays source-of-income; get;
+      """
+    Then concept identifiers are
+      |     | check | value                       |
+      | EMP | label | employment                  |
+      | TRN | label | transport-employment        |
+      | AVI | label | aviation-employment         |
+      | FAA | label | flight-attendant-employment |
+    Then uniquely identify answer concepts
+      | x   |
+      | EMP |
+      | TRN |
+      | AVI |
+      | FAA |
+
+
+  Scenario: define relation subtype inherits 'has' from its parent type
+    Given graql define
+      """
+      define contract-employment sub employment, relates contractor as employee;
+      """
+    Given the integrity is validated
+
+    When get answers of graql query
+      """
+      match $x has start-date; get;
+      """
+    Then concept identifiers are
+      |     | check | value               |
+      | EMP | label | employment          |
+      | CEM | label | contract-employment |
+    Then uniquely identify answer concepts
+      | x   |
+      | EMP |
+      | CEM |
+
+
+  Scenario: define relation subtype inherits 'has' from all of its supertypes
+    Given graql define
+      """
+      define
+      transport-employment sub employment, relates transport-worker as employee;
+      aviation-employment sub transport-employment, relates aviation-worker as transport-worker;
+      flight-attendant-employment sub aviation-employment, relates flight-attendant as aviation-worker;
+      """
+    Given the integrity is validated
+
+    When get answers of graql query
+      """
+      match $x has start-date; get;
+      """
+    Then concept identifiers are
+      |     | check | value                       |
+      | EMP | label | employment                  |
+      | TRN | label | transport-employment        |
+      | AVI | label | aviation-employment         |
+      | FAA | label | flight-attendant-employment |
+    Then uniquely identify answer concepts
+      | x   |
+      | EMP |
+      | TRN |
+      | AVI |
+      | FAA |
+
+
+  Scenario: define relation subtype inherits 'key' from its parent type
+    Given graql define
+      """
+      define contract-employment sub employment, relates contractor as employee;
+      """
+    Given the integrity is validated
+
+    When get answers of graql query
+      """
+      match $x key employment-reference-code; get;
+      """
+    Then concept identifiers are
+      |     | check | value               |
+      | EMP | label | employment          |
+      | CEM | label | contract-employment |
+    Then uniquely identify answer concepts
+      | x   |
+      | EMP |
+      | CEM |
+
+
+  Scenario: define relation subtype inherits 'key' from all of its supertypes
+    Given graql define
+      """
+      define
+      transport-employment sub employment, relates transport-worker as employee;
+      aviation-employment sub transport-employment, relates aviation-worker as transport-worker;
+      flight-attendant-employment sub aviation-employment, relates flight-attendant as aviation-worker;
+      """
+    Given the integrity is validated
+
+    When get answers of graql query
+      """
+      match $x key employment-reference-code; get;
+      """
+    Then concept identifiers are
+      |     | check | value                       |
+      | EMP | label | employment                  |
+      | TRN | label | transport-employment        |
+      | AVI | label | aviation-employment         |
+      | FAA | label | flight-attendant-employment |
+    Then uniquely identify answer concepts
+      | x   |
+      | EMP |
+      | TRN |
+      | AVI |
+      | FAA |
+
+
+  Scenario: define abstract relation type creates a type
+    Given graql define
+      """
+      define membership sub relation, abstract, relates member;
+      """
+    Given the integrity is validated
+    When get answers of graql query
+      """
+      match $x type membership; get;
+      """
+    Then concept identifiers are
+      |     | check | value      |
+      | MEM | label | membership |
+    Then uniquely identify answer concepts
+      | x   |
+      | MEM |
+
+
+  Scenario: define concrete subtype of abstract entity creates child of its parent type
+    Given graql define
+      """
+      define
+      membership sub relation, abstract, relates member;
+      gym-membership sub membership, relates gym-with-members, relates gym-member as member;
+      """
+    Given the integrity is validated
+
+    When get answers of graql query
+      """
+      match $x sub membership; get;
+      """
+    Then concept identifiers are
+      |     | check | value          |
+      | MEM | label | membership     |
+      | GYM | label | gym-membership |
+    Then uniquely identify answer concepts
+      | x   |
+      | MEM |
+      | GYM |
+
+
+  Scenario: define abstract subtype of abstract entity creates child of its parent type
+    Given graql define
+      """
+      define
+      requirement sub relation, abstract, relates prerequisite, relates outcome;
+      tool-requirement sub requirement, abstract, relates required-tool as prerequisite;
+      """
+    Given the integrity is validated
+
+    When get answers of graql query
+      """
+      match $x sub requirement; get;
+      """
+    Then concept identifiers are
+      |     | check | value            |
+      | REQ | label | requirement      |
+      | TLR | label | tool-requirement |
+    Then uniquely identify answer concepts
+      | x   |
+      | REQ |
+      | TLR |
+
+
+  Scenario: define abstract relation type with no roleplayers creates a type
+    Given graql define
+      """
+      define connection sub relation, abstract;
+      """
+    Given the integrity is validated
+    When get answers of graql query
+      """
+      match $x type connection; get;
+      """
+    Then concept identifiers are
+      |     | check | value      |
+      | CON | label | connection |
+    Then uniquely identify answer concepts
+      | x   |
+      | CON |
+
+
   @ignore
   # re-enable when we can inherit 'relates
   Scenario: define additional 'relates' is visible from all children
@@ -338,11 +740,126 @@ Feature: Graql Define Query
       | PART_TIME | EMPLOYER |
 
 
+  ##############
+  # ATTRIBUTES #
+  ##############
+
+
+  Scenario: define attribute creates a type
+    Given graql define
+      """
+      define favourite-food sub attribute, value string;
+      """
+    Given the integrity is validated
+    When get answers of graql query
+      """
+      match $x type favourite-food; get;
+      """
+    Then concept identifiers are
+      |     | check | value          |
+      | FAV | label | favourite-food |
+    Then uniquely identify answer concepts
+      | x   |
+      | FAV |
+
+
+  Scenario: define attribute subtype creates child of its parent type
+    Given graql define
+      """
+      define first-name sub name;
+      """
+    Given the integrity is validated
+
+    When get answers of graql query
+      """
+      match $x sub name; get;
+      """
+    Then concept identifiers are
+      |        | check | value      |
+      | NAME   | label | name       |
+      | F_NAME | label | first-name |
+    Then uniquely identify answer concepts
+      | x      |
+      | NAME   |
+      | F_NAME |
+
+
+  Scenario: define attribute subtype inherits 'value' from its parent
+    Given graql define
+      """
+      define first-name sub name;
+      """
+    Given the integrity is validated
+
+    When get answers of graql query
+      """
+      match $x type first-name, value string; get;
+      """
+    Then concept identifiers are
+      |        | check | value      |
+      | F_NAME | label | first-name |
+    Then uniquely identify answer concepts
+      | x      |
+      | F_NAME |
+
+
+  Scenario: define attribute type throws if you don't specify 'value'
+    Then graql define throws
+      """
+      define colour sub attribute;
+      """
+
+
+  Scenario: define attribute type throws if 'value' is invalid
+    Then graql define throws
+      """
+      define colour sub attribute, value rgba;
+      """
+
+
+  @Ignore
+  # re-enable when overriding an attribute's 'value' is forbidden
+  Scenario: define attribute subtype throws if you try to override 'value'
+    Then graql define throws
+      """
+      define code-name sub name, value long;
+      """
+
+
+  Scenario: define attribute regex creates a regex
+    Given graql define
+      """
+      define response sub attribute, value string, regex "^(yes|no|maybe)$";
+      """
+    Given the integrity is validated
+    When get answers of graql query
+      """
+      match $x regex "^(yes|no|maybe)$"; get;
+      """
+    Then concept identifiers are
+      |     | check | value    |
+      | RES | label | response |
+    Then uniquely identify answer concepts
+      | x   |
+      | RES |
+
+
+  Scenario: define attribute regex throws if value is a long
+    Then graql define throws
+      """
+      define name-in-binary sub attribute, value long, regex "^(0|1)+$";
+      """
+
+
+  Scenario: define attribute subtype inherits 'plays' from supertypes
+
+  Scenario: define attribute subtype inherits 'has' from supertypes
+
+  Scenario: define attribute subtype inherits 'key' from supertypes
+
   Scenario: define a type as abstract errors if has non-abstract parent types (?)
 
   Scenario: define a type as abstract creates an abstract type
-
-  Scenario: define a regex on an attribute type, attribute type queryable by regex value
 
   Scenario: define a rule creates a rule (?)
 
@@ -355,21 +872,27 @@ Feature: Graql Define Query
       match $x sub relation; get; 
       """
     Then concept identifiers are
-      |           | check | value          |
-      | REL       | label | relation       |
-      | EMP       | label | employment     |
-      | HAS_ATTR  | label | @has-attribute |
-      | HAS_NAME  | label | @has-name      |
-      | KEY_ATTR  | label | @key-attribute |
-      | KEY_EMAIL | label | @key-email     |
+      |           | check | value                          |
+      | REL       | label | relation                       |
+      | EMP       | label | employment                     |
+      | INC       | label | income                         |
+      | HAS_ATTR  | label | @has-attribute                 |
+      | HAS_NAME  | label | @has-name                      |
+      | HAS_SDATE | label | @has-start-date                |
+      | KEY_ATTR  | label | @key-attribute                 |
+      | KEY_EMAIL | label | @key-email                     |
+      | KEY_EMREF | label | @key-employment-reference-code |
     Then uniquely identify answer concepts
       | x         |
       | REL       |
       | EMP       |
+      | INC       |
       | HAS_ATTR  |
       | HAS_NAME  |
+      | HAS_SDATE |
       | KEY_ATTR  |
       | KEY_EMAIL |
+      | KEY_EMREF |
 
 
   Scenario: implicit attribute ownerships exist in a hierarchy matching attribute hierarchy
@@ -388,16 +911,18 @@ Feature: Graql Define Query
       | ATTR   | label | @has-attribute  |
       | NAME   | label | @has-name       |
       | F_NAME | label | @has-first-name |
+      | S_DATE | label | @has-start-date |
     Then uniquely identify answer concepts
       | child  | super  |
       | ATTR   | ATTR   |
       | NAME   | ATTR   |
       | F_NAME | ATTR   |
+      | S_DATE | ATTR   |
       | NAME   | NAME   |
       | F_NAME | NAME   |
       | F_NAME | F_NAME |
+      | S_DATE | S_DATE |
 
-  Scenario: define a relation with no related roles throws on commit
 
   Scenario: define a rule with nested negation throws on commit
 
@@ -410,6 +935,4 @@ Feature: Graql Define Query
   Scenario: define a non-insertable `then` throws on commit (eg. missing specific roles, or attribute value)
 
   Scenario: define a rule causing a loop throws on commit (eg. conclusion is negated in the `when`)
-
-
 

--- a/behaviour/graql/language/define.feature
+++ b/behaviour/graql/language/define.feature
@@ -479,10 +479,14 @@ Feature: Graql Define Query
       | EMP |
       | PTT |
 
-    # TODO - should employee role be retrieving part-timer as well?
+    # TODO - should employee role be retrieving part-timer as well? yes
 
     # Then query 1 has 2 answers
     # And answers of query 1 satisfy: match $x sub employment; get;
+
+
+  # @ignore
+  Scenario: define a sub-role using 'as' is visible from children (?)
 
 
   Scenario: define relation subtype inherits 'plays' from its parent type
@@ -650,7 +654,7 @@ Feature: Graql Define Query
       | MEM |
 
 
-  Scenario: define concrete subtype of abstract entity creates child of its parent type
+  Scenario: define concrete subtype of abstract relation creates child of its parent type
     Given graql define
       """
       define
@@ -1080,68 +1084,12 @@ Feature: Graql Define Query
 
   Scenario: define a type as abstract errors if has non-abstract parent types (?)
 
-  Scenario: define a rule creates a rule (?)
 
-  Scenario: define a sub-role using 'as' is visible from children (?)
+  #########
+  # RULES #
+  #########
 
-
-  Scenario: define an attribute key- and owner-ship creates the implicit attribute key/ownership relation types
-    When get answers of graql query
-      """
-      match $x sub relation; get; 
-      """
-    Then concept identifiers are
-      |           | check | value                          |
-      | REL       | label | relation                       |
-      | EMP       | label | employment                     |
-      | INC       | label | income                         |
-      | HAS_ATTR  | label | @has-attribute                 |
-      | HAS_NAME  | label | @has-name                      |
-      | HAS_SDATE | label | @has-start-date                |
-      | KEY_ATTR  | label | @key-attribute                 |
-      | KEY_EMAIL | label | @key-email                     |
-      | KEY_EMREF | label | @key-employment-reference-code |
-    Then uniquely identify answer concepts
-      | x         |
-      | REL       |
-      | EMP       |
-      | INC       |
-      | HAS_ATTR  |
-      | HAS_NAME  |
-      | HAS_SDATE |
-      | KEY_ATTR  |
-      | KEY_EMAIL |
-      | KEY_EMREF |
-
-
-  Scenario: implicit attribute ownerships exist in a hierarchy matching attribute hierarchy
-    Given graql define
-      """
-      define first-name sub name; person sub entity, has first-name;
-      """
-    Given the integrity is validated
-
-    When get answers of graql query
-      """
-      match $child sub $super; $super sub @has-attribute; get; 
-      """
-    Then concept identifiers are
-      |        | check | value           |
-      | ATTR   | label | @has-attribute  |
-      | NAME   | label | @has-name       |
-      | F_NAME | label | @has-first-name |
-      | S_DATE | label | @has-start-date |
-    Then uniquely identify answer concepts
-      | child  | super  |
-      | ATTR   | ATTR   |
-      | NAME   | ATTR   |
-      | F_NAME | ATTR   |
-      | S_DATE | ATTR   |
-      | NAME   | NAME   |
-      | F_NAME | NAME   |
-      | F_NAME | F_NAME |
-      | S_DATE | S_DATE |
-
+  Scenario: define a rule creates a rule
 
   Scenario: define a rule with nested negation throws on commit
 
@@ -1154,4 +1102,8 @@ Feature: Graql Define Query
   Scenario: define a non-insertable `then` throws on commit (eg. missing specific roles, or attribute value)
 
   Scenario: define a rule causing a loop throws on commit (eg. conclusion is negated in the `when`)
+
+  #########################
+  # TODO: SCHEMA MUTATION #
+  #########################
 


### PR DESCRIPTION
This PR forms part of the work towards resolving:

Complete Axiomatic Tests - implement missing Graql query scenarios #18

It adds a large number of 'define' tests, as well as a new test step 'graql define throws' to be implemented in client-java and grakn.