### PR TITLE
Update graknlabs dependencies to use ones that use gRPC 1.29.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -54,10 +54,10 @@ checkstyle_dependencies()
 load("@graknlabs_build_tools//bazel:dependencies.bzl", "bazel_rules_python")
 bazel_rules_python()
 
-load("@io_bazel_rules_python//python:pip.bzl", "pip_import", "pip_repositories")
+load("@rules_python//python:pip.bzl", "pip_repositories", "pip3_import")
 pip_repositories()
 
-pip_import(
+pip3_import(
     name = "graknlabs_build_tools_ci_pip",
     requirements = "@graknlabs_build_tools//ci:requirements.txt",
 )

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -4,7 +4,7 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "6cf8cad67fa232d020869fde84e56984bf36d5e7", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "715e4802ea375abda44e24b2bb092ee14de72e42", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_common():
@@ -25,12 +25,12 @@ def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
         remote = "https://github.com/graknlabs/client-java",
-        commit = "fb02d4b2b126b38a5a0ee002ba658315bf4d4b96",
+        commit = "a94e7eaa96795f515598321ad23ac9b59b03aefa",
     )
 
 def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
-        commit = "ce41e8667d25cb13eeb3812662501cf6aa27cdc9",
+        commit = "5bdba205c4cc6cdc06ee76c5177d9386c6431d84",
     )


### PR DESCRIPTION
## What is the goal of this PR?

We have updated graknlabs dependencies to use ones that use gRPC 1.29.0