### PR TITLE
Migrate Type Generation & Hierarchy Reasoner tests to Resolution BDDs

### DIFF
--- a/behaviour/graql/reasoner/BUILD
+++ b/behaviour/graql/reasoner/BUILD
@@ -18,6 +18,6 @@
 package(default_visibility = ["//visibility:public"])
 
 exports_files([
-    "reasoner.feature",
     "resolution.feature",
+    "rule-validation.feature",
 ])

--- a/behaviour/graql/reasoner/resolution.feature
+++ b/behaviour/graql/reasoner/resolution.feature
@@ -1,5 +1,19 @@
-# Constraints
-#  Only scenarios where there is only one possible resolution path can be tested in this way
+#
+# Copyright (C) 2020 Grakn Labs
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
 
 # TODO: these tests should be implemented somewhere, but probably not in a file called 'resolution.feature'
 Feature: Graql Reasoner Resolution

--- a/behaviour/graql/reasoner/resolution/BUILD
+++ b/behaviour/graql/reasoner/resolution/BUILD
@@ -21,5 +21,6 @@ exports_files([
     "attribute-attachment.feature",
     "test-framework.feature",
     "type-generation.feature",
+    "type-hierarchy.feature",
     "value-predicate.feature",
 ])

--- a/behaviour/graql/reasoner/resolution/BUILD
+++ b/behaviour/graql/reasoner/resolution/BUILD
@@ -19,5 +19,7 @@ package(default_visibility = ["//visibility:public"])
 
 exports_files([
     "attribute-attachment.feature",
-    "value-predicate.feature"
+    "test-framework.feature",
+    "type-generation.feature",
+    "value-predicate.feature",
 ])

--- a/behaviour/graql/reasoner/resolution/attribute-attachment.feature
+++ b/behaviour/graql/reasoner/resolution/attribute-attachment.feature
@@ -57,7 +57,6 @@ Feature: Attribute Attachment Resolution
       is-old sub attribute, value boolean;
       sub-string-attribute sub string-attribute;
       unrelated-attribute sub attribute, value string;
-      ref sub attribute, value long;
       """
 
 

--- a/behaviour/graql/reasoner/resolution/attribute-attachment.feature
+++ b/behaviour/graql/reasoner/resolution/attribute-attachment.feature
@@ -37,23 +37,19 @@ Feature: Attribute Attachment Resolution
           has unrelated-attribute,
           has sub-string-attribute,
           has age,
-          has is-old,
-          key ref;
+          has is-old;
 
       tortoise sub entity,
           has age,
-          has is-old,
-          key ref;
+          has is-old;
 
       soft-drink sub entity,
-          has retailer,
-          key ref;
+          has retailer;
 
       team sub relation,
           relates leader,
           relates team-member,
-          has string-attribute,
-          key ref;
+          has string-attribute;
 
       string-attribute sub attribute, value string;
       retailer sub attribute, value string;
@@ -82,8 +78,8 @@ Feature: Attribute Attachment Resolution
     Given for each session, graql insert
       """
       insert
-      $geX isa person, has string-attribute "banana", has ref 0;
-      $geY isa person, has ref 1;
+      $geX isa person, has string-attribute "banana";
+      $geY isa person;
       """
 #    When materialised keyspace is completed
     Then for graql query
@@ -134,8 +130,8 @@ Feature: Attribute Attachment Resolution
     Given for each session, graql insert
       """
       insert
-      $geX isa person, has string-attribute "banana", has ref 0;
-      $geY isa person, has ref 1;
+      $geX isa person, has string-attribute "banana";
+      $geY isa person;
       """
 #    When materialised keyspace is completed
     Then for graql query
@@ -150,7 +146,7 @@ Feature: Attribute Attachment Resolution
       """
     # four attributes for each entity
 #    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 8
+    Then answer size in reasoned keyspace is: 6
 #    Then materialised and reasoned keyspaces are the same size
 
 
@@ -170,7 +166,7 @@ Feature: Attribute Attachment Resolution
     Given for each session, graql insert
       """
       insert
-      $geX isa person, has string-attribute "banana", has ref 0;
+      $geX isa person, has string-attribute "banana";
       """
 #    When materialised keyspace is completed
     Then for graql query
@@ -211,8 +207,8 @@ Feature: Attribute Attachment Resolution
     Given for each session, graql insert
       """
       insert
-      $geX isa person, has string-attribute "banana", has ref 0;
-      $geY isa person, has ref 1;
+      $geX isa person, has string-attribute "banana";
+      $geY isa person;
       """
 #    When materialised keyspace is completed
     Then for graql query
@@ -256,9 +252,9 @@ Feature: Attribute Attachment Resolution
     Given for each session, graql insert
       """
       insert
-      $geX isa person, has string-attribute "banana", has ref 0;
-      $geY isa person, has ref 1;
-      (leader:$geX, team-member:$geX) isa team, has ref 2;
+      $geX isa person, has string-attribute "banana";
+      $geY isa person;
+      (leader:$geX, team-member:$geX) isa team;
       """
 #    When materialised keyspace is completed
     Then for graql query
@@ -296,8 +292,8 @@ Feature: Attribute Attachment Resolution
     Given for each session, graql insert
       """
       insert
-      $aeX isa soft-drink, has ref 0;
-      $aeY isa soft-drink, has ref 1;
+      $aeX isa soft-drink;
+      $aeY isa soft-drink;
       $r "Ocado" isa retailer;
       """
 #    When materialised keyspace is completed
@@ -340,8 +336,8 @@ Feature: Attribute Attachment Resolution
     Given for each session, graql insert
       """
       insert
-      $aeX isa soft-drink, has ref 0;
-      $aeY isa soft-drink, has ref 1;
+      $aeX isa soft-drink;
+      $aeY isa soft-drink;
       $r "Ocado" isa retailer;
       """
 #    When materialised keyspace is completed

--- a/behaviour/graql/reasoner/resolution/test-framework.feature
+++ b/behaviour/graql/reasoner/resolution/test-framework.feature
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-Feature: Reasoning
+Feature: Resolution Test Framework
 
   Background: Set up keyspaces for resolution testing
 

--- a/behaviour/graql/reasoner/resolution/test-framework.feature
+++ b/behaviour/graql/reasoner/resolution/test-framework.feature
@@ -34,11 +34,9 @@ Feature: Resolution Test Framework
       define
 
       name sub attribute, value string;
-      company-id sub attribute, value long;
 
       company sub entity,
-        has name,
-        key company-id;
+        has name;
 
       company-has-name sub rule,
       when {
@@ -50,9 +48,8 @@ Feature: Resolution Test Framework
     Given for each session, graql insert
       """
       insert
-      $x isa company, has company-id 0;
+      $x isa company;
       """
-
     When materialised keyspace is completed
     Then for graql query
       """
@@ -73,11 +70,7 @@ Feature: Resolution Test Framework
       is-liable sub attribute,
           value boolean;
 
-      company-id sub attribute,
-          value long;
-
       company sub entity,
-          key company-id,
           has name,
           has is-liable;
 
@@ -98,7 +91,7 @@ Feature: Resolution Test Framework
     Given for each session, graql insert
       """
       insert
-      $co isa company, has company-id 0;
+      $co isa company;
       """
 
     When materialised keyspace is completed
@@ -120,7 +113,7 @@ Feature: Resolution Test Framework
 
       location sub entity,
           abstract,
-          key name,
+          has name,
           plays superior,
           plays subordinate;
 
@@ -129,7 +122,6 @@ Feature: Resolution Test Framework
       country sub location;
 
       location-hierarchy sub relation,
-          key location-hierarchy-id,
           relates superior,
           relates subordinate;
 
@@ -147,15 +139,15 @@ Feature: Resolution Test Framework
       $ar isa area, has name "King's Cross";
       $cit isa city, has name "London";
       $cntry isa country, has name "UK";
-      (superior: $cntry, subordinate: $cit) isa location-hierarchy, has location-hierarchy-id 0;
-      (superior: $cit, subordinate: $ar) isa location-hierarchy, has location-hierarchy-id 1;
+      (superior: $cntry, subordinate: $cit) isa location-hierarchy;
+      (superior: $cit, subordinate: $ar) isa location-hierarchy;
       """
 
     When materialised keyspace is completed
     Then for graql query
       """
       match
-      $k isa area, has name $n;
+      $k isa entity, has name "King's Cross";
       (superior: $l, subordinate: $k) isa location-hierarchy;
       get;
       """
@@ -175,7 +167,7 @@ Feature: Resolution Test Framework
 
       location sub entity,
           abstract,
-          key name,
+          has name,
           plays location-hierarchy_superior,
           plays location-hierarchy_subordinate;
 
@@ -185,7 +177,6 @@ Feature: Resolution Test Framework
       continent sub location;
 
       location-hierarchy sub relation,
-          key location-hierarchy-id,
           relates location-hierarchy_superior,
           relates location-hierarchy_subordinate;
 
@@ -204,9 +195,9 @@ Feature: Resolution Test Framework
       $cit isa city, has name "London";
       $cntry isa country, has name "UK";
       $cont isa continent, has name "Europe";
-      (location-hierarchy_superior: $cont, location-hierarchy_subordinate: $cntry) isa location-hierarchy, has location-hierarchy-id 0;
-      (location-hierarchy_superior: $cntry, location-hierarchy_subordinate: $cit) isa location-hierarchy, has location-hierarchy-id 1;
-      (location-hierarchy_superior: $cit, location-hierarchy_subordinate: $ar) isa location-hierarchy, has location-hierarchy-id 2;
+      (location-hierarchy_superior: $cont, location-hierarchy_subordinate: $cntry) isa location-hierarchy;
+      (location-hierarchy_superior: $cntry, location-hierarchy_subordinate: $cit) isa location-hierarchy;
+      (location-hierarchy_superior: $cit, location-hierarchy_subordinate: $ar) isa location-hierarchy;
       """
 
     When materialised keyspace is completed
@@ -227,11 +218,7 @@ Feature: Resolution Test Framework
 
       name sub attribute, value string;
 
-      person-id sub attribute, value long;
-      siblingship-id sub attribute, value long;
-
       person sub entity,
-          key person-id,
           has name,
           plays sibling;
 
@@ -242,7 +229,6 @@ Feature: Resolution Test Framework
         abstract;
 
       siblingship sub family-relation,
-          key siblingship-id,
           relates sibling;
 
       a-man-is-called-bob sub rule,
@@ -263,8 +249,8 @@ Feature: Resolution Test Framework
     Given for each session, graql insert
       """
       insert
-      $a isa woman, has person-id 0, has name "Alice";
-      $b isa man, has person-id 1;
+      $a isa woman, has name "Alice";
+      $b isa man;
       """
 
     When materialised keyspace is completed
@@ -288,11 +274,7 @@ Feature: Resolution Test Framework
       is-liable sub attribute,
           value boolean;
 
-      company-id sub attribute,
-          value long;
-
       company sub entity,
-          key company-id,
           has name,
           has is-liable;
 
@@ -306,9 +288,9 @@ Feature: Resolution Test Framework
     Given for each session, graql insert
       """
       insert
-      $c1 isa company, has company-id 0;
+      $c1 isa company;
       $c1 has name $n1; $n1 "the-company";
-      $c2 isa company, has company-id 1;
+      $c2 isa company;
       $c2 has name $n2; $n2 "another-company";
       """
 
@@ -335,11 +317,7 @@ Feature: Resolution Test Framework
       is-liable sub attribute,
           value boolean;
 
-      company-id sub attribute,
-          value long;
-
       company sub entity,
-          key company-id,
           has name,
           has is-liable;
 
@@ -356,9 +334,9 @@ Feature: Resolution Test Framework
     Given for each session, graql insert
       """
       insert
-      $c1 isa company, has company-id 0;
+      $c1 isa company;
       $c1 has name $n1; $n1 "the-company";
-      $c2 isa company, has company-id 1;
+      $c2 isa company;
       $c2 has name $n2; $n2 "another-company";
       """
 
@@ -382,11 +360,7 @@ Feature: Resolution Test Framework
       is-liable sub attribute,
           value boolean;
 
-      company-id sub attribute,
-          value long;
-
       company sub entity,
-          key company-id,
           has name,
           has is-liable;
 
@@ -401,9 +375,9 @@ Feature: Resolution Test Framework
     Given for each session, graql insert
       """
       insert
-      $c1 isa company, has company-id 0;
+      $c1 isa company;
       $c1 has name $n1; $n1 "the-company";
-      $c2 isa company, has company-id 1;
+      $c2 isa company;
       $c2 has name $n2; $n2 "another-company";
       """
 

--- a/behaviour/graql/reasoner/resolution/test-framework.feature
+++ b/behaviour/graql/reasoner/resolution/test-framework.feature
@@ -155,6 +155,8 @@ Feature: Resolution Test Framework
     Then materialised and reasoned keyspaces are the same size
 
 
+  @ignore
+  # TODO: currently this scenario takes longer than 2 hours to execute (#75) - re-enable when fixed
   Scenario: 3-hop transitivity
     Given for each session, graql define
       """

--- a/behaviour/graql/reasoner/resolution/type-generation.feature
+++ b/behaviour/graql/reasoner/resolution/type-generation.feature
@@ -1,0 +1,298 @@
+#
+# Copyright (C) 2020 Grakn Labs
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+Feature: Type Generation Resolution
+
+  Background: Set up keyspaces for resolution testing
+
+    Given connection has been opened
+    Given connection delete all keyspaces
+    Given connection open sessions for keyspaces:
+      | materialised |
+      | reasoned     |
+    Given materialised keyspace is named: materialised
+    Given reasoned keyspace is named: reasoned
+
+
+  # TODO: re-enable all steps when things do not require keys in resolution testing
+  Scenario: additional types for entities can be derived using `isa`
+    Given for each session, graql define
+      """
+      define
+      baseEntity sub entity;
+      derivedEntity sub entity;
+      rule-1 sub rule,
+      when {
+        $x isa baseEntity;
+      },
+      then {
+        $x isa derivedEntity;
+      };
+      """
+    Given for each session, graql insert
+      """
+      insert
+      $x isa baseEntity;
+      """
+#    When materialised keyspace is completed
+    Then for graql query
+      """
+      match $x isa derivedEntity; get;
+      """
+#    Then all answers are correct in reasoned keyspace
+    Then answer size in reasoned keyspace is: 1
+    Then for graql query
+      """
+      match $x isa $type; get;
+      """
+#    Then all answers are correct in reasoned keyspace
+    Then answer size in reasoned keyspace is: 4
+#    Then materialised and reasoned keyspaces are the same size
+
+
+  # TODO: re-enable all steps when things do not require keys in resolution testing
+  Scenario: additional types for entities can be derived using direct `isa!`
+    Given for each session, graql define
+      """
+      define
+
+      baseEntity sub entity;
+      subEntity sub baseEntity;
+      subSubEntity sub subEntity;
+
+      derivedEntity sub entity;
+      directDerivedEntity sub derivedEntity;
+
+      isaRule sub rule,
+      when {
+        $x isa subEntity;
+      },
+      then {
+        $x isa derivedEntity;
+      };
+
+      directIsaRule sub rule,
+      when {
+        $x isa! subEntity;
+      },
+      then {
+        $x isa directDerivedEntity;
+      };
+      """
+    Given for each session, graql insert
+      """
+      insert
+      $x isa baseEntity;
+      $y isa subEntity;    # -> derivedEntity, directDerivedEntity
+      $z isa subSubEntity; # -> derivedEntity
+      """
+#    When materialised keyspace is completed
+    Then for graql query
+      """
+      match $x isa derivedEntity; get;
+      """
+#    Then all answers are correct in reasoned keyspace
+    Then answer size in reasoned keyspace is: 2
+    Then for graql query
+      """
+      match $x isa! derivedEntity; get;
+      """
+#    Then all answers are correct in reasoned keyspace
+    Then answer size in reasoned keyspace is: 2
+    Then for graql query
+      """
+      match $x isa directDerivedEntity; get;
+      """
+#    Then all answers are correct in reasoned keyspace
+    Then answer size in reasoned keyspace is: 1
+#    Then materialised and reasoned keyspaces are the same size
+
+
+  # TODO: re-enable all steps when things do not require keys in resolution testing
+  Scenario: additional types for entities can be derived via relations that they play roles in
+    Given for each session, graql define
+      """
+      define
+
+      baseEntity sub entity,
+          plays role1,
+          plays role2;
+
+      derivedEntity sub entity,
+          plays role1,
+          plays role2;
+
+      baseRelation sub relation,
+          relates role1,
+          relates role2;
+
+      rule-1 sub rule,
+      when {
+          (role1:$x, role2:$y) isa baseRelation;
+          (role1:$y, role2:$x) isa baseRelation;
+      },
+      then {
+          $x isa derivedEntity;
+      };
+      """
+    Given for each session, graql insert
+      """
+      insert
+      $x isa baseEntity;
+      $y isa baseEntity;
+      (role1:$x, role2:$y) isa baseRelation;
+      (role1:$y, role2:$x) isa baseRelation;
+      """
+#    When materialised keyspace is completed
+    Then for graql query
+      """
+      match $x isa baseEntity; get;
+      """
+#    Then all answers are correct in reasoned keyspace
+    Then answer size in reasoned keyspace is: 2
+    Then for graql query
+      """
+      match
+        $x isa derivedEntity;
+      get;
+      """
+#    Then all answers are correct in reasoned keyspace
+    Then answer size in reasoned keyspace is: 2
+#    Then materialised and reasoned keyspaces are the same size
+
+
+  @ignore
+  # TODO: re-enable when grakn#5824 is fixed (matching a variable with two types)
+  Scenario: additional types for entities can be derived via attributes that they own
+    Given for each session, graql define
+      """
+      define
+
+      baseEntity sub entity,
+          has baseAttribute;
+
+      derivedEntity sub entity,
+          has baseAttribute;
+
+      baseAttribute sub attribute, value string;
+
+      rule1
+      when {
+          $x has baseAttribute "derived";
+      },
+      then {
+          $x isa derivedEntity;
+      };
+      """
+    Given for each session, graql insert
+      """
+      insert
+      $x isa baseEntity, has baseAttribute "derived";
+      """
+#    When materialised keyspace is completed
+    Then for graql query
+      """
+      match $x isa baseEntity; get;
+      """
+#    Then all answers are correct in reasoned keyspace
+    Then answer size in reasoned keyspace is: 1
+    Then for graql query
+      """
+      match $x isa baseAttribute; get;
+      """
+#    Then all answers are correct in reasoned keyspace
+    Then answer size in reasoned keyspace is: 1
+    Then for graql query
+      """
+      match
+        $x isa derivedEntity;
+        $x isa baseEntity;
+      get;
+      """
+#    Then all answers are correct in reasoned keyspace
+    Then answer size in reasoned keyspace is: 1
+#    Then materialised and reasoned keyspaces are the same size
+
+
+  # TODO: re-enable all steps when things do not require keys in resolution testing
+  Scenario: additional types for relations can be derived using direct `isa!`
+    Given for each session, graql define
+      """
+      define
+
+      baseEntity sub entity,
+          plays baseRole;
+
+      baseRelation sub relation,
+          relates baseRole;
+      subRelation sub baseRelation,
+          relates baseRole;
+      subSubRelation sub subRelation,
+          relates baseRole;
+
+      derivedRelation sub relation,
+          relates baseRole;
+      directDerivedRelation sub derivedRelation,
+          relates baseRole;
+
+      relationRule sub rule,
+      when {
+          ($x) isa subRelation;
+      },
+      then {
+          ($x) isa derivedRelation;
+      };
+
+      directRelationRule sub rule,
+      when {
+          ($x) isa! subRelation;
+      },
+      then {
+          ($x) isa directDerivedRelation;
+      };
+      """
+    Given for each session, graql insert
+      """
+      insert
+      $x isa baseEntity;
+      $y isa baseEntity;
+      $z isa baseEntity;
+
+      (baseRole: $x) isa baseRelation;
+      (baseRole: $y) isa subRelation;
+      (baseRole: $z) isa subSubRelation;
+      """
+#    When materialised keyspace is completed
+    Then for graql query
+      """
+      match ($x) isa derivedRelation; get;
+      """
+#    Then all answers are correct in reasoned keyspace
+    Then answer size in reasoned keyspace is: 2
+    Then for graql query
+      """
+      match ($x) isa! derivedRelation; get;
+      """
+#    Then all answers are correct in reasoned keyspace
+    Then answer size in reasoned keyspace is: 2
+    Then for graql query
+      """
+      match ($x) isa directDerivedRelation; get;
+      """
+#    Then all answers are correct in reasoned keyspace
+    Then answer size in reasoned keyspace is: 1
+#    Then materialised and reasoned keyspaces are the same size

--- a/behaviour/graql/reasoner/resolution/type-generation.feature
+++ b/behaviour/graql/reasoner/resolution/type-generation.feature
@@ -28,7 +28,7 @@ Feature: Type Generation Resolution
     Given reasoned keyspace is named: reasoned
 
 
-  # TODO: re-enable all steps when things do not require keys in resolution testing
+  # TODO: re-enable all steps once attribute re-attachment is resolvable
   Scenario: additional types for entities can be derived using `isa`
     Given for each session, graql define
       """
@@ -64,7 +64,7 @@ Feature: Type Generation Resolution
 #    Then materialised and reasoned keyspaces are the same size
 
 
-  # TODO: re-enable all steps when things do not require keys in resolution testing
+  # TODO: re-enable all steps once attribute re-attachment is resolvable
   Scenario: additional types for entities can be derived using direct `isa!`
     Given for each session, graql define
       """
@@ -122,7 +122,7 @@ Feature: Type Generation Resolution
 #    Then materialised and reasoned keyspaces are the same size
 
 
-  # TODO: re-enable all steps when things do not require keys in resolution testing
+  # TODO: re-enable all steps once attribute re-attachment is resolvable
   Scenario: additional types for entities can be derived via relations that they play roles in
     Given for each session, graql define
       """
@@ -228,7 +228,7 @@ Feature: Type Generation Resolution
 #    Then materialised and reasoned keyspaces are the same size
 
 
-  # TODO: re-enable all steps when things do not require keys in resolution testing
+  # TODO: re-enable all steps once attribute re-attachment is resolvable
   Scenario: additional types for relations can be derived using direct `isa!`
     Given for each session, graql define
       """

--- a/behaviour/graql/reasoner/resolution/type-hierarchy.feature
+++ b/behaviour/graql/reasoner/resolution/type-hierarchy.feature
@@ -1,0 +1,125 @@
+#
+# Copyright (C) 2020 Grakn Labs
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+Feature: Type Hierarchy Resolution
+
+  Background: Set up keyspaces for resolution testing
+
+    Given connection has been opened
+    Given connection delete all keyspaces
+    Given connection open sessions for keyspaces:
+      | materialised |
+      | reasoned     |
+    Given materialised keyspace is named: materialised
+    Given reasoned keyspace is named: reasoned
+
+
+  Scenario: when matching different roles to those that are actually inferred, no answers are returned
+    Given for each session, graql define
+      """
+      define
+
+      entity1 sub entity,
+          plays role1,
+          plays role2,
+          plays role3;
+
+      relation1 sub relation,
+          relates role1,
+          relates role2;
+
+      relation2 sub relation,
+          relates role1,
+          relates role2,
+          relates role3;
+
+      rule-1 sub rule,
+      when {
+          (role1:$x, role2:$y) isa relation1;
+      },
+      then {
+          (role1:$x, role3:$y) isa relation2;
+      };
+      """
+    Given for each session, graql insert
+      """
+      insert
+      $x isa entity1;
+      $y isa entity1;
+      (role1:$x, role2:$y) isa relation1;
+      """
+    When materialised keyspace is completed
+    Then for graql query
+      """
+      match (role2:$x, role3:$y) isa relation2; get;
+      """
+    Then no answers are resolved in reasoned keyspace
+    Then answer size in reasoned keyspace is: 0
+    Then materialised and reasoned keyspaces are the same size
+
+
+  Scenario: when a relation with sub-roles is inferred, it can be retrieved by matching their super-roles
+    Given for each session, graql define
+      """
+      define
+
+      role1 sub role;
+      role2 sub role;
+      role3 sub role1;
+      role4 sub role2;
+
+      entity1 sub entity,
+          plays role1,
+          plays role2,
+          plays role3,
+          plays role4;
+
+      relation1 sub relation,
+          relates role1,
+          relates role2;
+
+      relation2 sub relation,
+          relates role1,
+          relates role2;
+
+      relation3 sub relation2,
+          relates role3,
+          relates role4;
+
+      rule-1 sub rule,
+      when {
+          (role1:$x, role2:$y) isa relation1;
+      },
+      then {
+          (role3:$x, role4:$y) isa relation3;
+      };
+      """
+    Given for each session, graql insert
+      """
+      insert
+      $x isa entity1;
+      $y isa entity1;
+      (role1:$x, role2:$y) isa relation1;
+      """
+    When materialised keyspace is completed
+    Then for graql query
+      """
+      match (role1:$x, role2:$y) isa relation2; get;
+      """
+    Then all answers are correct in reasoned keyspace
+    Then answer size in reasoned keyspace is: 1
+    Then materialised and reasoned keyspaces are the same size

--- a/behaviour/graql/reasoner/resolution/type-hierarchy.feature
+++ b/behaviour/graql/reasoner/resolution/type-hierarchy.feature
@@ -67,7 +67,6 @@ Feature: Type Hierarchy Resolution
       """
       match (role2:$x, role3:$y) isa relation2; get;
       """
-    Then no answers are resolved in reasoned keyspace
     Then answer size in reasoned keyspace is: 0
     Then materialised and reasoned keyspaces are the same size
 

--- a/behaviour/graql/reasoner/resolution/type-hierarchy.feature
+++ b/behaviour/graql/reasoner/resolution/type-hierarchy.feature
@@ -123,3 +123,350 @@ Feature: Type Hierarchy Resolution
     Then all answers are correct in reasoned keyspace
     Then answer size in reasoned keyspace is: 1
     Then materialised and reasoned keyspaces are the same size
+
+
+  Scenario: subtypes trigger rules based on their parents; parent types don't trigger rules based on their children
+    Given for each session, graql define
+      """
+      define
+
+      entity1 sub entity,
+          has name,
+          plays role1,
+          plays role2;
+
+      subEntity1 sub entity1;
+
+      relation1 sub relation,
+          relates role1,
+          relates role2;
+
+      relation2 sub relation,
+          relates role1,
+          relates role2;
+
+      name sub attribute, value string;
+
+      rule-1 sub rule,
+      when {
+          $x isa subEntity1;
+          $y isa entity1;
+          (role1:$x, role2:$y) isa relation2;
+      },
+      then {
+          (role1:$x, role2:$y) isa relation1;
+      };
+      """
+    Given for each session, graql insert
+      """
+      insert
+      $x isa subEntity1, has name "a";
+      $y isa entity1, has name "b";
+      $z isa entity1, has name "a";
+      $w isa entity1, has name "b2";
+      $v isa subEntity1, has name "a";
+
+      (role1:$x, role2:$z) isa relation2;     # subEntity1 - entity1    -> satisfies rule
+      (role1:$y, role2:$z) isa relation2;     # entity1 - entity1       -> doesn't satisfy rule
+      (role1:$x, role2:$v) isa relation2;     # subEntity1 - subEntity1 -> satisfies rule
+      (role1:$y, role2:$v) isa relation2;     # entity1 - subEntity1    -> doesn't satisfy rule
+      """
+    When materialised keyspace is completed
+    Then for graql query
+      """
+      match
+        $x isa entity1;
+        $y isa entity1;
+        (role1: $x, role2: $y) isa relation1;
+      get;
+      """
+    Then all answers are correct in reasoned keyspace
+    # Answers are (role1:$x, role2:$z) and (role1:$x, role2:$v)
+    Then answer size in reasoned keyspace is: 2
+    Then for graql query
+      """
+      match
+        $x isa entity1;
+        $y isa entity1;
+        (role1: $x, role2: $y) isa relation1;
+        $y has name 'a';
+      get;
+      """
+    Then all answers are correct in reasoned keyspace
+    Then answer size in reasoned keyspace is: 2
+    Then for graql query
+      """
+      match
+        $x isa entity1;
+        $y isa subEntity1;
+        (role1: $x, role2: $y) isa relation1;
+      get;
+      """
+    Then all answers are correct in reasoned keyspace
+    # Answer is (role1:$x, role2:$v) ONLY
+    Then answer size in reasoned keyspace is: 1
+    Then for graql query
+      """
+      match
+        $x isa entity1;
+        $y isa subEntity1;
+        (role1: $x, role2: $y) isa relation1;
+        $y has name 'a';
+      get;
+      """
+    Then all answers are correct in reasoned keyspace
+    Then answer size in reasoned keyspace is: 1
+    Then for graql query
+      """
+      match
+        $x isa subEntity1;
+        $y isa entity1;
+        (role1: $x, role2: $y) isa relation1;
+      get;
+      """
+    Then all answers are correct in reasoned keyspace
+    # Answers are (role1:$x, role2:$z) and (role1:$x, role2:$v)
+    Then answer size in reasoned keyspace is: 2
+    Then for graql query
+      """
+      match
+        $x isa subEntity1;
+        $y isa entity1;
+        (role1: $x, role2: $y) isa relation1;
+        $y has name 'a';
+      get;
+      """
+    Then all answers are correct in reasoned keyspace
+    Then answer size in reasoned keyspace is: 2
+    Then materialised and reasoned keyspaces are the same size
+
+
+  Scenario: when a rule is recursive, its inferences respect type hierarchies
+    Given for each session, graql define
+      """
+      define
+
+      entity1 sub entity,
+          has name,
+          plays role1,
+          plays role2;
+
+      subEntity1 sub entity1;
+
+      relation1 sub relation,
+          relates role1,
+          relates role2;
+
+      relation2 sub relation,
+          relates role1,
+          relates role2;
+
+      name sub attribute, value string;
+
+      rule-1 sub rule,
+      when {
+          $x isa subEntity1;
+          $y isa entity1;
+          (role1:$x, role2:$y) isa relation2;
+      },
+      then {
+          (role1:$x, role2:$y) isa relation1;
+      };
+
+      rule-2 sub rule,
+      when {
+          $x isa entity1;
+          $y isa subEntity1;
+          (role1:$x, role2:$y) isa relation2;
+      },
+      then {
+          (role1:$x, role2:$y) isa relation2;
+      };
+      """
+    Given for each session, graql insert
+      """
+      insert
+      $x isa subEntity1, has name "a";
+      $y isa entity1, has name "b";
+      $z isa entity1, has name "a";
+      $w isa entity1, has name "b2";
+      $v isa subEntity1, has name "a";
+
+      (role1:$x, role2:$z) isa relation2;     # subEntity1 - entity1    -> satisfies rule
+      (role1:$y, role2:$z) isa relation2;     # entity1 - entity1       -> doesn't satisfy rule
+      (role1:$x, role2:$v) isa relation2;     # subEntity1 - subEntity1 -> satisfies rule
+      (role1:$y, role2:$v) isa relation2;     # entity1 - subEntity1    -> doesn't satisfy rule
+      """
+    When materialised keyspace is completed
+    Then for graql query
+      """
+      match
+        $x isa entity1;
+        $y isa entity1;
+        (role1: $x, role2: $y) isa relation1;
+      get;
+      """
+    Then all answers are correct in reasoned keyspace
+    # Answers are (role1:$x, role2:$z) and (role1:$x, role2:$v)
+    Then answer size in reasoned keyspace is: 2
+    Then for graql query
+      """
+      match
+        $x isa entity1;
+        $y isa entity1;
+        (role1: $x, role2: $y) isa relation1;
+        $y has name 'a';
+      get;
+      """
+    Then all answers are correct in reasoned keyspace
+    Then answer size in reasoned keyspace is: 2
+    Then for graql query
+      """
+      match
+        $x isa entity1;
+        $y isa subEntity1;
+        (role1: $x, role2: $y) isa relation1;
+      get;
+      """
+    Then all answers are correct in reasoned keyspace
+    # Answer is (role1:$x, role2:$v) ONLY
+    Then answer size in reasoned keyspace is: 1
+    Then for graql query
+      """
+      match
+        $x isa entity1;
+        $y isa subEntity1;
+        (role1: $x, role2: $y) isa relation1;
+        $y has name 'a';
+      get;
+      """
+    Then all answers are correct in reasoned keyspace
+    Then answer size in reasoned keyspace is: 1
+    Then for graql query
+      """
+      match
+        $x isa subEntity1;
+        $y isa entity1;
+        (role1: $x, role2: $y) isa relation1;
+      get;
+      """
+    Then all answers are correct in reasoned keyspace
+    # Answers are (role1:$x, role2:$z) and (role1:$x, role2:$v)
+    Then answer size in reasoned keyspace is: 2
+    Then for graql query
+      """
+      match
+        $x isa subEntity1;
+        $y isa entity1;
+        (role1: $x, role2: $y) isa relation1;
+        $y has name 'a';
+      get;
+      """
+    Then all answers are correct in reasoned keyspace
+    Then answer size in reasoned keyspace is: 2
+    Then materialised and reasoned keyspaces are the same size
+
+
+  Scenario: querying for a super-relation gives the same answer as querying for its inferred sub-relation
+    Given for each session, graql define
+      """
+      define
+
+      entity1 sub entity,
+          plays role1,
+          plays role2;
+
+      relation1 sub relation,
+          relates role1,
+          relates role2;
+
+      sub-relation1 sub relation1,
+          relates role1,
+          relates role2;
+
+      relation2 sub relation,
+          relates role1,
+          relates role2;
+
+      rule-1 sub rule,
+      when {
+          (role1:$x, role2:$y) isa relation2;
+      },
+      then {
+          (role1:$x, role2:$y) isa sub-relation1;
+      };
+      """
+    Given for each session, graql insert
+      """
+      insert
+      $x isa entity1;
+      $y isa entity1;
+      (role1:$x, role2:$y) isa relation2;
+      """
+    When materialised keyspace is completed
+    Then for graql query
+      """
+      match
+        (role1: $x, role2: $y) isa relation1;
+      get;
+      """
+    Then all answers are correct in reasoned keyspace
+    Then answer size in reasoned keyspace is: 1
+    Then for graql query
+      """
+      match
+        (role1: $x, role2: $y) isa relation1;
+        (role1: $x, role2: $y) isa sub-relation1;
+      get;
+      """
+    Then all answers are correct in reasoned keyspace
+    Then answer size in reasoned keyspace is: 1
+    Then materialised and reasoned keyspaces are the same size
+
+
+  # TODO: re-enable all steps once attribute re-attachment is resolvable
+  Scenario: querying for a super-entity gives the same answer as querying for its inferred sub-entity
+    Given for each session, graql define
+      """
+      define
+
+      #Entities
+
+      baseEntity sub entity;
+      subEntity sub baseEntity;
+      anotherBaseEntity sub entity;
+
+      #Rules
+
+      rule-1 sub rule,
+      when {
+          $x isa anotherBaseEntity;
+      },
+      then {
+          $x isa subEntity;
+      };
+      """
+    Given for each session, graql insert
+      """
+      insert
+      $x isa anotherBaseEntity;
+      """
+#    When materialised keyspace is completed
+    Then for graql query
+      """
+      match
+        $x isa baseEntity;
+      get;
+      """
+#    Then all answers are correct in reasoned keyspace
+    Then answer size in reasoned keyspace is: 1
+    Then for graql query
+      """
+      match
+        $x isa baseEntity;
+        $x isa subEntity;
+      get;
+      """
+#    Then all answers are correct in reasoned keyspace
+    Then answer size in reasoned keyspace is: 1
+#    Then materialised and reasoned keyspaces are the same size

--- a/behaviour/graql/reasoner/resolution/value-predicate.feature
+++ b/behaviour/graql/reasoner/resolution/value-predicate.feature
@@ -389,7 +389,7 @@ Feature: Value Predicate Resolution
       $x isa soft-drink, has name "Fanta";
       $y isa soft-drink, has name "Tango";
       """
-    When materialised keyspace is completed
+#    When materialised keyspace is completed
     Then for graql query
       """
       match
@@ -449,7 +449,7 @@ Feature: Value Predicate Resolution
       $x isa soft-drink, has name "Fanta";
       $y isa soft-drink, has name "Tango";
       """
-    When materialised keyspace is completed
+#    When materialised keyspace is completed
     Then for graql query
       """
       match

--- a/behaviour/graql/reasoner/resolution/value-predicate.feature
+++ b/behaviour/graql/reasoner/resolution/value-predicate.feature
@@ -38,24 +38,20 @@ Feature: Value Predicate Resolution
         has sub-string-attribute,
         has name,
         has age,
-        has is-old,
-        key ref;
+        has is-old;
 
       tortoise sub entity,
         has age,
-        has is-old,
-        key ref;
+        has is-old;
 
       soft-drink sub entity,
         has name,
-        has retailer,
-        key ref;
+        has retailer;
 
       team sub relation,
         relates leader,
         relates team-member,
-        has string-attribute,
-        key ref;
+        has string-attribute;
 
       string-attribute sub attribute, value string;
       retailer sub attribute, value string;
@@ -64,7 +60,6 @@ Feature: Value Predicate Resolution
       is-old sub attribute, value boolean;
       sub-string-attribute sub string-attribute;
       unrelated-attribute sub attribute, value string;
-      ref sub attribute, value long;
       """
 
 
@@ -86,7 +81,7 @@ Feature: Value Predicate Resolution
     Given for each session, graql insert
       """
       insert
-      $se isa tortoise, has age 1, has ref 0;
+      $se isa tortoise, has age 1;
       """
     When materialised keyspace is completed
     Then for graql query
@@ -112,8 +107,8 @@ Feature: Value Predicate Resolution
     Given for each session, graql insert
       """
       insert
-      $x isa person, has ref 0;
-      $y isa person, has ref 1;
+      $x isa person;
+      $y isa person;
       """
     When materialised keyspace is completed
     Then for graql query
@@ -150,15 +145,15 @@ Feature: Value Predicate Resolution
     Given for each session, graql insert
       """
       insert
-      $x isa person, has name "Alice", has ref 0;
-      $y isa person, has name "Bob", has ref 1;
+      $x isa person, has name "Alice";
+      $y isa person, has name "Bob";
       """
     When materialised keyspace is completed
     Then for graql query
       """
       match
-        $x isa person, has ref 0, has lucky-number $m;
-        $y isa person, has ref 1, has lucky-number $n;
+        $x isa person, has lucky-number $m;
+        $y isa person, has lucky-number $n;
         $m <op> $n;
       get;
       """
@@ -190,15 +185,15 @@ Feature: Value Predicate Resolution
     Given for each session, graql insert
       """
       insert
-      $x isa person, has ref 0;
-      $y isa person, has ref 1;
+      $x isa person;
+      $y isa person;
       """
     When materialised keyspace is completed
     Then for graql query
       """
       match
-        $x isa person, has ref 0, has lucky-number $m;
-        $y isa person, has ref 1, has lucky-number $n;
+        $x isa person, has lucky-number $m;
+        $y isa person, has lucky-number $n;
         $m <op> $n;
         $n <op> 1667;
       get;
@@ -243,8 +238,8 @@ Feature: Value Predicate Resolution
     Given for each session, graql insert
       """
       insert
-      $x isa soft-drink, has name "Fanta", has ref 0;
-      $y isa soft-drink, has name "Tango", has ref 1;
+      $x isa soft-drink, has name "Fanta";
+      $y isa soft-drink, has name "Tango";
       $r "Ocado" isa retailer;
       """
 #    When materialised keyspace is completed
@@ -290,8 +285,8 @@ Feature: Value Predicate Resolution
     Given for each session, graql insert
       """
       insert
-      $x isa soft-drink, has name "Fanta", has ref 0;
-      $y isa soft-drink, has name "Tango", has ref 1;
+      $x isa soft-drink, has name "Fanta";
+      $y isa soft-drink, has name "Tango";
       $r "Ocado" isa retailer;
       """
 #    When materialised keyspace is completed
@@ -343,7 +338,7 @@ Feature: Value Predicate Resolution
       """
     Given for each session, graql insert
       """
-      insert $x isa soft-drink, has name "Fanta", has ref 0;
+      insert $x isa soft-drink, has name "Fanta";
       """
     When materialised keyspace is completed
     Then for graql query
@@ -391,8 +386,8 @@ Feature: Value Predicate Resolution
     Given for each session, graql insert
       """
       insert
-      $x isa soft-drink, has name "Fanta", has ref 0;
-      $y isa soft-drink, has name "Tango", has ref 1;
+      $x isa soft-drink, has name "Fanta";
+      $y isa soft-drink, has name "Tango";
       """
     When materialised keyspace is completed
     Then for graql query
@@ -451,8 +446,8 @@ Feature: Value Predicate Resolution
     Given for each session, graql insert
       """
       insert
-      $x isa soft-drink, has name "Fanta", has ref 0;
-      $y isa soft-drink, has name "Tango", has ref 1;
+      $x isa soft-drink, has name "Fanta";
+      $y isa soft-drink, has name "Tango";
       """
     When materialised keyspace is completed
     Then for graql query
@@ -512,8 +507,8 @@ Feature: Value Predicate Resolution
     Given for each session, graql insert
       """
       insert
-      $x isa soft-drink, has name "Fanta", has ref 0;
-      $y isa soft-drink, has name "Tango", has ref 1;
+      $x isa soft-drink, has name "Fanta";
+      $y isa soft-drink, has name "Tango";
       $r "Ocado" isa retailer;
       """
 #    When materialised keyspace is completed
@@ -567,8 +562,8 @@ Feature: Value Predicate Resolution
     Given for each session, graql insert
       """
       insert
-      $x isa soft-drink, has name "Fanta", has ref 0;
-      $y isa soft-drink, has name "Tango", has ref 1;
+      $x isa soft-drink, has name "Fanta";
+      $y isa soft-drink, has name "Tango";
       $r "Ocado" isa retailer;
       """
 #    When materialised keyspace is completed
@@ -623,8 +618,8 @@ Feature: Value Predicate Resolution
     Given for each session, graql insert
       """
       insert
-      $x isa soft-drink, has name "Fanta", has ref 0;
-      $y isa soft-drink, has name "Tango", has ref 1;
+      $x isa soft-drink, has name "Fanta";
+      $y isa soft-drink, has name "Tango";
       $r "Ocado" isa retailer;
       """
 #    When materialised keyspace is completed
@@ -671,9 +666,9 @@ Feature: Value Predicate Resolution
     Given for each session, graql insert
       """
       insert
-      $x isa person, has name "Alice", has string-attribute "Tesco", has ref 0;
-      $y isa person, has name "Bob", has string-attribute "Safeway", has ref 1;
-      $z isa soft-drink, has name "Tango", has ref 2;
+      $x isa person, has name "Alice", has string-attribute "Tesco";
+      $y isa person, has name "Bob", has string-attribute "Safeway";
+      $z isa soft-drink, has name "Tango";
       """
 #    When materialised keyspace is completed
     Then for graql query
@@ -719,9 +714,9 @@ Feature: Value Predicate Resolution
     Given for each session, graql insert
       """
       insert
-      $x isa person, has name "Alice", has string-attribute "Tesco", has ref 0;
-      $y isa person, has name "Bob", has string-attribute "Safeway", has ref 1;
-      $z isa soft-drink, has name "Tango", has ref 2;
+      $x isa person, has name "Alice", has string-attribute "Tesco";
+      $y isa person, has name "Bob", has string-attribute "Safeway";
+      $z isa soft-drink, has name "Tango";
       """
 #    When materialised keyspace is completed
     Then for graql query
@@ -762,8 +757,8 @@ Feature: Value Predicate Resolution
     Given for each session, graql insert
       """
       insert
-      $x isa person, has string-attribute "Tesco", has ref 0;
-      $y isa soft-drink, has name "Tesco", has ref 1;
+      $x isa person, has string-attribute "Tesco";
+      $y isa soft-drink, has name "Tesco";
       """
 #    When materialised keyspace is completed
     Then for graql query
@@ -809,8 +804,8 @@ Feature: Value Predicate Resolution
     Given for each session, graql insert
       """
       insert
-      $x isa person, has string-attribute "Tesco", has ref 0;
-      $y isa soft-drink, has name "Tesco", has ref 1;
+      $x isa person, has string-attribute "Tesco";
+      $y isa soft-drink, has name "Tesco";
       """
 #    When materialised keyspace is completed
     Then for graql query
@@ -875,9 +870,9 @@ Feature: Value Predicate Resolution
     Given for each session, graql insert
       """
       insert
-      $w isa person, has string-attribute "Ocado", has ref 0;
-      $x isa person, has string-attribute "Tesco", has ref 1;
-      $y isa soft-drink, has name "Sprite", has ref 2;
+      $w isa person, has string-attribute "Ocado";
+      $x isa person, has string-attribute "Tesco";
+      $y isa soft-drink, has name "Sprite";
       $z "Ocado" isa retailer;
       """
 #    When materialised keyspace is completed

--- a/behaviour/graql/reasoner/resolution/value-predicate.feature
+++ b/behaviour/graql/reasoner/resolution/value-predicate.feature
@@ -152,8 +152,8 @@ Feature: Value Predicate Resolution
     Then for graql query
       """
       match
-        $x isa person, has lucky-number $m;
-        $y isa person, has lucky-number $n;
+        $x isa person, has name "Alice", has lucky-number $m;
+        $y isa person, has name "Bob", has lucky-number $n;
         $m <op> $n;
       get;
       """
@@ -185,15 +185,15 @@ Feature: Value Predicate Resolution
     Given for each session, graql insert
       """
       insert
-      $x isa person;
-      $y isa person;
+      $x isa person, has name "Alice";
+      $y isa person, has name "Bob";
       """
     When materialised keyspace is completed
     Then for graql query
       """
       match
-        $x isa person, has lucky-number $m;
-        $y isa person, has lucky-number $n;
+        $x isa person, has name "Alice", has lucky-number $m;
+        $y isa person, has name "Bob", has lucky-number $n;
         $m <op> $n;
         $n <op> 1667;
       get;

--- a/behaviour/graql/reasoner/rule-validation.feature
+++ b/behaviour/graql/reasoner/rule-validation.feature
@@ -1,0 +1,110 @@
+#
+# Copyright (C) 2020 Grakn Labs
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+Feature: Graql Reasoner Rule Validation
+
+  Background: Initialise a session and transaction for each scenario
+    Given connection has been opened
+    Given connection delete all keyspaces
+    Given connection open sessions for keyspaces:
+      | test_rule_validation |
+    Given transaction is initialised
+
+
+  Scenario: when defining a rule to generate new entities from existing ones, an error is thrown
+    Given graql define
+      """
+      define
+
+      baseEntity sub entity;
+      derivedEntity sub entity;
+      """
+    Given the integrity is validated
+    Then graql define throws
+      """
+      define
+      rule-1 sub rule,
+      when {
+          $x isa baseEntity;
+      },
+      then {
+          $y isa derivedEntity;
+      };
+      """
+    Then the integrity is validated
+
+
+  Scenario: when defining a rule to generate new entities from existing relations, an error is thrown
+    Given graql define
+      """
+      define
+
+      baseEntity sub entity,
+          plays role1,
+          plays role2;
+
+      derivedEntity sub entity,
+          plays role1,
+          plays role2;
+
+      baseRelation sub relation,
+          relates role1,
+          relates role2;
+      """
+    Given the integrity is validated
+    Then graql define throws
+      """
+      define
+      rule-1 sub rule,
+      when {
+          (role1:$x, role2:$y) isa baseRelation;
+          (role1:$y, role2:$z) isa baseRelation;
+      },
+      then {
+          $u isa derivedEntity;
+      };
+      """
+    Then the integrity is validated
+
+
+  Scenario: when defining a rule to generate new relations from existing ones, an error is thrown
+    Given graql define
+      """
+      define
+
+      baseEntity sub entity,
+          plays role1,
+          plays role2;
+
+      baseRelation sub relation,
+          relates role1,
+          relates role2;
+      """
+    Given the integrity is validated
+    Then graql define throws
+      """
+      define
+      rule-1 sub rule,
+      when {
+          (role1:$x, role2:$y) isa baseRelation;
+          (role1:$y, role2:$z) isa baseRelation;
+      },
+      then {
+          $u (role1:$x, role2:$z) isa baseRelation;
+      };
+      """
+    Then the integrity is validated


### PR DESCRIPTION
## What is the goal of this PR?

To migrate our Graql Reasoner Type Generation and Type Hierarchies ITs to Resolution BDDs.

This PR forms part of the work towards https://github.com/graknlabs/grakn/issues/5721

## What are the changes implemented in this PR?

Added new BDD scenarios, many of which were migrated from TypeGenerationIT and TypeHierarchiesIT in grakn
