### PR TITLE
Rename keyspace to database

### DIFF
--- a/behaviour/concept/thing/attribute.feature
+++ b/behaviour/concept/thing/attribute.feature
@@ -19,10 +19,10 @@ Feature: Concept Attribute
 
   Background:
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection does not have any keyspace
-    Given connection create keyspace: grakn
-    Given connection open schema session for keyspace: grakn
+    Given connection delete all databases
+    Given connection does not have any database
+    Given connection create database: grakn
+    Given connection open schema session for database: grakn
     Given session opens transaction of type: write
     # Write schema for the test scenarios
     Given put attribute type: is-alive, with value type: boolean
@@ -41,7 +41,7 @@ Feature: Concept Attribute
     Given entity(person) set has attribute type: birth-date
     Given transaction commits
     Given connection close all sessions
-    Given connection open data session for keyspace: grakn
+    Given connection open data session for database: grakn
     Given session opens transaction of type: write
 
   Scenario: Attribute with value type boolean can be created

--- a/behaviour/concept/thing/entity.feature
+++ b/behaviour/concept/thing/entity.feature
@@ -19,10 +19,10 @@ Feature: Concept Entity
 
   Background:
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection does not have any keyspace
-    Given connection create keyspace: grakn
-    Given connection open schema session for keyspace: grakn
+    Given connection delete all databases
+    Given connection does not have any database
+    Given connection create database: grakn
+    Given connection open schema session for database: grakn
     Given session opens transaction of type: write
     # Write schema for the test scenarios
     Given put attribute type: username, with value type: string
@@ -32,7 +32,7 @@ Feature: Concept Entity
     Given entity(person) set has attribute type: email
     Given transaction commits
     Given connection close all sessions
-    Given connection open data session for keyspace: grakn
+    Given connection open data session for database: grakn
     Given session opens transaction of type: write
 
   Scenario: Entity can be created

--- a/behaviour/concept/thing/relation.feature
+++ b/behaviour/concept/thing/relation.feature
@@ -19,10 +19,10 @@ Feature: Concept Relation
 
   Background:
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection does not have any keyspace
-    Given connection create keyspace: grakn
-    Given connection open schema session for keyspace: grakn
+    Given connection delete all databases
+    Given connection does not have any database
+    Given connection create database: grakn
+    Given connection open schema session for database: grakn
     Given session opens transaction of type: write
     # Write schema for the test scenarios
     Given put attribute type: username, with value type: string
@@ -39,7 +39,7 @@ Feature: Concept Relation
     Given entity(person) set plays role: marriage:husband
     Given transaction commits
     Given connection close all sessions
-    Given connection open data session for keyspace: grakn
+    Given connection open data session for database: grakn
     Given session opens transaction of type: write
 
   Scenario: Relation with role players can be created and role players can be retrieved

--- a/behaviour/concept/type/attributetype.feature
+++ b/behaviour/concept/type/attributetype.feature
@@ -19,10 +19,10 @@ Feature: Concept Attribute Type
 
   Background:
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection does not have any keyspace
-    Given connection create keyspace: grakn
-    Given connection open schema session for keyspace: grakn
+    Given connection delete all databases
+    Given connection does not have any database
+    Given connection create database: grakn
+    Given connection open schema session for database: grakn
     Given session opens transaction of type: write
 
   Scenario: Attribute types can be created
@@ -109,12 +109,12 @@ Feature: Concept Attribute Type
     When put attribute type: name, with value type: string
     When transaction commits
     When connection close all sessions
-    When connection open data session for keyspace: grakn
+    When connection open data session for database: grakn
     When session opens transaction of type: write
     When $x = attribute(name) as(string) put: alice
     When transaction commits
     When connection close all sessions
-    When connection open schema session for keyspace: grakn
+    When connection open schema session for database: grakn
     When session opens transaction of type: write
     Then delete attribute type: name; throws exception
 

--- a/behaviour/concept/type/entitytype.feature
+++ b/behaviour/concept/type/entitytype.feature
@@ -19,10 +19,10 @@ Feature: Concept Entity Type
 
   Background:
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection does not have any keyspace
-    Given connection create keyspace: grakn
-    Given connection open schema session for keyspace: grakn
+    Given connection delete all databases
+    Given connection does not have any database
+    Given connection create database: grakn
+    Given connection open schema session for database: grakn
     Given session opens transaction of type: write
 
   Scenario: Entity types can be created
@@ -66,12 +66,12 @@ Feature: Concept Entity Type
     When put entity type: person
     When transaction commits
     When connection close all sessions
-    When connection open data session for keyspace: grakn
+    When connection open data session for database: grakn
     When session opens transaction of type: write
     When $x = entity(person) create new instance
     When transaction commits
     When connection close all sessions
-    When connection open schema session for keyspace: grakn
+    When connection open schema session for database: grakn
     When session opens transaction of type: write
     Then delete entity type: person; throws exception
 

--- a/behaviour/concept/type/relationtype.feature
+++ b/behaviour/concept/type/relationtype.feature
@@ -19,10 +19,10 @@ Feature: Concept Relation Type and Role Type
 
   Background:
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection does not have any keyspace
-    Given connection create keyspace: grakn
-    Given connection open schema session for keyspace: grakn
+    Given connection delete all databases
+    Given connection does not have any database
+    Given connection create database: grakn
+    Given connection open schema session for database: grakn
     Given session opens transaction of type: write
 
   Scenario: Relation and role types can be created
@@ -99,14 +99,14 @@ Feature: Concept Relation Type and Role Type
     When entity(person) set plays role: marriage:wife
     When transaction commits
     When connection close all sessions
-    When connection open data session for keyspace: grakn
+    When connection open data session for database: grakn
     When session opens transaction of type: write
     When $m = relation(marriage) create new instance
     When $a = entity(person) create new instance
     When relation $m set player for role(wife): $a
     When transaction commits
     When connection close all sessions
-    When connection open schema session for keyspace: grakn
+    When connection open schema session for database: grakn
     When session opens transaction of type: write
     Then delete relation type: marriage; throws exception
 

--- a/behaviour/concept/type/thingtype.feature
+++ b/behaviour/concept/type/thingtype.feature
@@ -19,10 +19,10 @@ Feature: Concept Thing Type
 
   Background:
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection does not have any keyspace
-    Given connection create keyspace: grakn
-    Given connection open schema session for keyspace: grakn
+    Given connection delete all databases
+    Given connection does not have any database
+    Given connection create database: grakn
+    Given connection open schema session for database: grakn
     Given session opens transaction of type: write
 
   Scenario: Root thing type can retrieve all types
@@ -74,7 +74,7 @@ Feature: Concept Thing Type
     When entity(person) set has key type: username
     When transaction commits
     When connection close all sessions
-    When connection open data session for keyspace: grakn
+    When connection open data session for database: grakn
     When session opens transaction of type: write
     When $att1 = attribute(is-alive) as(boolean) put: true
     When $att2 = attribute(age) as(long) put: 21

--- a/behaviour/connection/BUILD
+++ b/behaviour/connection/BUILD
@@ -18,7 +18,7 @@
 package(default_visibility = ["//visibility:public"])
 
 exports_files([
-    "keyspace.feature",
+    "database.feature",
     "session.feature",
     "transaction.feature",
 ])

--- a/behaviour/connection/database.feature
+++ b/behaviour/connection/database.feature
@@ -15,21 +15,21 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-Feature: Connection Keyspace
+Feature: Connection Database
 
   Background:
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection does not have any keyspace
+    Given connection delete all databases
+    Given connection does not have any database
 
-  Scenario: create one keyspace
-    When  connection create keyspace:
+  Scenario: create one database
+    When  connection create database:
       | alice   |
-    Then  connection has keyspace:
+    Then  connection has database:
       | alice   |
 
-  Scenario: create many keyspaces
-    When  connection create keyspaces:
+  Scenario: create many databases
+    When  connection create databases:
       | alice   |
       | bob     |
       | charlie |
@@ -42,35 +42,7 @@ Feature: Connection Keyspace
       | judy    |
       | mike    |
       | neil    |
-    Then  connection has keyspaces:
-      | alice   |
-      | bob     |
-      | charlie |
-      | dylan   |
-      | eve     |
-      | frank   |
-      | george  |
-      | heidi   |
-      | ivan    |
-      | judy    |
-      | mike    |
-      | neil    |
-
-  Scenario: create many keyspaces in parallel
-    When  connection create keyspaces in parallel:
-      | alice   |
-      | bob     |
-      | charlie |
-      | dylan   |
-      | eve     |
-      | frank   |
-      | george  |
-      | heidi   |
-      | ivan    |
-      | judy    |
-      | mike    |
-      | neil    |
-    Then  connection has keyspaces:
+    Then  connection has databases:
       | alice   |
       | bob     |
       | charlie |
@@ -84,19 +56,47 @@ Feature: Connection Keyspace
       | mike    |
       | neil    |
 
-  Scenario: delete one keyspace
+  Scenario: create many databases in parallel
+    When  connection create databases in parallel:
+      | alice   |
+      | bob     |
+      | charlie |
+      | dylan   |
+      | eve     |
+      | frank   |
+      | george  |
+      | heidi   |
+      | ivan    |
+      | judy    |
+      | mike    |
+      | neil    |
+    Then  connection has databases:
+      | alice   |
+      | bob     |
+      | charlie |
+      | dylan   |
+      | eve     |
+      | frank   |
+      | george  |
+      | heidi   |
+      | ivan    |
+      | judy    |
+      | mike    |
+      | neil    |
+
+  Scenario: delete one database
       # This step should be rewritten once we can create keypsaces without opening sessions
-    Given connection create keyspace:
+    Given connection create database:
       | alice   |
-    When  connection delete keyspace:
+    When  connection delete database:
       | alice   |
-    Then  connection does not have keyspace:
+    Then  connection does not have database:
       | alice   |
-    Then  connection does not have any keyspace
+    Then  connection does not have any database
 
-  Scenario: connection can delete many keyspaces
+  Scenario: connection can delete many databases
       # This step should be rewritten once we can create keypsaces without opening sessions
-    Given connection create keyspaces:
+    Given connection create databases:
       | alice   |
       | bob     |
       | charlie |
@@ -109,7 +109,7 @@ Feature: Connection Keyspace
       | judy    |
       | mike    |
       | neil    |
-    When  connection delete keyspaces:
+    When  connection delete databases:
       | alice   |
       | bob     |
       | charlie |
@@ -122,7 +122,7 @@ Feature: Connection Keyspace
       | judy    |
       | mike    |
       | neil    |
-    Then  connection does not have keyspaces:
+    Then  connection does not have databases:
       | alice   |
       | bob     |
       | charlie |
@@ -135,11 +135,11 @@ Feature: Connection Keyspace
       | judy    |
       | mike    |
       | neil    |
-    Then  connection does not have any keyspace
+    Then  connection does not have any database
 
-  Scenario: delete many keyspaces in parallel
+  Scenario: delete many databases in parallel
       # This step should be rewritten once we can create keypsaces without opening sessions
-    Given connection create keyspaces in parallel:
+    Given connection create databases in parallel:
       | alice   |
       | bob     |
       | charlie |
@@ -152,7 +152,7 @@ Feature: Connection Keyspace
       | judy    |
       | mike    |
       | neil    |
-    When  connection delete keyspaces in parallel:
+    When  connection delete databases in parallel:
       | alice   |
       | bob     |
       | charlie |
@@ -165,7 +165,7 @@ Feature: Connection Keyspace
       | judy    |
       | mike    |
       | neil    |
-    Then  connection does not have keyspaces:
+    Then  connection does not have databases:
       | alice   |
       | bob     |
       | charlie |
@@ -178,4 +178,4 @@ Feature: Connection Keyspace
       | judy    |
       | mike    |
       | neil    |
-    Then  connection does not have any keyspace
+    Then  connection does not have any database

--- a/behaviour/connection/session.feature
+++ b/behaviour/connection/session.feature
@@ -19,23 +19,23 @@ Feature: Connection Session
 
   Background:
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection does not have any keyspace
+    Given connection delete all databases
+    Given connection does not have any database
 
-  Scenario: for one keyspace, open one session
-    When connection create keyspace:
+  Scenario: for one database, open one session
+    When connection create database:
       | grakn   |
-    When connection open session for keyspace:
+    When connection open session for database:
       | grakn   |
     Then session is null: false
     Then session is open: true
-    Then session has keyspace:
+    Then session has database:
       | grakn   |
 
-  Scenario: for one keyspace, open many sessions
-    When connection create keyspace:
+  Scenario: for one database, open many sessions
+    When connection create database:
       | grakn   |
-    When connection open sessions for keyspaces:
+    When connection open sessions for databases:
       | grakn   |
       | grakn   |
       | grakn   |
@@ -50,7 +50,7 @@ Feature: Connection Session
       | grakn   |
     Then sessions are null: false
     Then sessions are open: true
-    Then sessions have keyspaces:
+    Then sessions have databases:
       | grakn   |
       | grakn   |
       | grakn   |
@@ -64,10 +64,10 @@ Feature: Connection Session
       | grakn   |
       | grakn   |
 
-  Scenario: for one keyspace, open many sessions in parallel
-    When connection create keyspace:
+  Scenario: for one database, open many sessions in parallel
+    When connection create database:
       | grakn   |
-    When connection open sessions in parallel for keyspaces:
+    When connection open sessions in parallel for databases:
       | grakn   |
       | grakn   |
       | grakn   |
@@ -82,7 +82,7 @@ Feature: Connection Session
       | grakn   |
     Then sessions in parallel are null: false
     Then sessions in parallel are open: true
-    Then sessions in parallel have keyspaces:
+    Then sessions in parallel have databases:
       | grakn   |
       | grakn   |
       | grakn   |
@@ -96,8 +96,8 @@ Feature: Connection Session
       | grakn   |
       | grakn   |
 
-  Scenario: for many keyspaces, open many sessions
-    When connection create keyspaces:
+  Scenario: for many databases, open many sessions
+    When connection create databases:
       | alice   |
       | bob     |
       | charlie |
@@ -110,7 +110,7 @@ Feature: Connection Session
       | judy    |
       | mike    |
       | neil    |
-    When connection open sessions for keyspaces:
+    When connection open sessions for databases:
       | alice   |
       | bob     |
       | charlie |
@@ -125,7 +125,7 @@ Feature: Connection Session
       | neil    |
     Then sessions are null: false
     Then sessions are open: true
-    Then sessions have keyspaces:
+    Then sessions have databases:
       | alice   |
       | bob     |
       | charlie |
@@ -139,8 +139,8 @@ Feature: Connection Session
       | mike    |
       | neil    |
 
-  Scenario: for many keyspaces, open many sessions in parallel
-    When connection create keyspaces:
+  Scenario: for many databases, open many sessions in parallel
+    When connection create databases:
       | alice   |
       | bob     |
       | charlie |
@@ -153,7 +153,7 @@ Feature: Connection Session
       | judy    |
       | mike    |
       | neil    |
-    When connection open sessions in parallel for keyspaces:
+    When connection open sessions in parallel for databases:
       | alice   |
       | bob     |
       | charlie |
@@ -168,7 +168,7 @@ Feature: Connection Session
       | neil    |
     Then sessions in parallel are null: false
     Then sessions in parallel are open: true
-    Then sessions in parallel have keyspaces:
+    Then sessions in parallel have databases:
       | alice   |
       | bob     |
       | charlie |

--- a/behaviour/connection/transaction.feature
+++ b/behaviour/connection/transaction.feature
@@ -19,13 +19,13 @@ Feature: Connection Transaction
 
   Background:
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection does not have any keyspace
+    Given connection delete all databases
+    Given connection does not have any database
 
-  Scenario: one keyspace, one session, one transaction to read
-    When connection create keyspace:
+  Scenario: one database, one session, one transaction to read
+    When connection create database:
       | grakn   |
-    Given connection open session for keyspace:
+    Given connection open session for database:
       | grakn   |
     When for each session, open transaction of type:
       | read    |
@@ -34,10 +34,10 @@ Feature: Connection Transaction
     Then for each session, transaction has type:
       | read    |
 
-  Scenario: one keyspace, one session, one transaction to write
-    When connection create keyspace:
+  Scenario: one database, one session, one transaction to write
+    When connection create database:
       | grakn   |
-    Given connection open session for keyspace:
+    Given connection open session for database:
       | grakn   |
     When for each session, open transaction of type:
       | write   |
@@ -46,30 +46,30 @@ Feature: Connection Transaction
     Then for each session, transaction has type:
       | write   |
 
-  Scenario: one keyspace, one session, one committed write transaction is closed
-    When connection create keyspace:
+  Scenario: one database, one session, one committed write transaction is closed
+    When connection create database:
       | grakn   |
-    Given connection open session for keyspace:
-      | grakn   |
-    When for each session, open transaction of type:
-      | write   |
-    Then for each session, transaction commits
-    Then for each session, transaction commits; throws exception
-
-  Scenario: one keyspace, one session, re-committing transaction throws
-    When connection create keyspace:
-      | grakn   |
-    Given connection open session for keyspace:
+    Given connection open session for database:
       | grakn   |
     When for each session, open transaction of type:
       | write   |
     Then for each session, transaction commits
     Then for each session, transaction commits; throws exception
 
-  Scenario: one keyspace, one session, transaction close is idempotent
-    When connection create keyspace:
+  Scenario: one database, one session, re-committing transaction throws
+    When connection create database:
       | grakn   |
-    Given connection open session for keyspace:
+    Given connection open session for database:
+      | grakn   |
+    When for each session, open transaction of type:
+      | write   |
+    Then for each session, transaction commits
+    Then for each session, transaction commits; throws exception
+
+  Scenario: one database, one session, transaction close is idempotent
+    When connection create database:
+      | grakn   |
+    Given connection open session for database:
       | grakn   |
     When for each session, open transaction of type:
       | write   |
@@ -79,10 +79,10 @@ Feature: Connection Transaction
     Then for each session, transaction is open: false
 
   @ignore-grakn-core
-  Scenario: one keyspace, one session, many transactions to read
-    When connection create keyspace:
+  Scenario: one database, one session, many transactions to read
+    When connection create database:
       | grakn   |
-    Given connection open session for keyspace:
+    Given connection open session for database:
       | grakn   |
     When for each session, open transactions of type:
       | read    |
@@ -114,10 +114,10 @@ Feature: Connection Transaction
       | read    |
 
   @ignore-grakn-core
-  Scenario: one keyspace, one session, many transactions to write
-    When connection create keyspace:
+  Scenario: one database, one session, many transactions to write
+    When connection create database:
       | grakn   |
-    Given connection open session for keyspace:
+    Given connection open session for database:
       | grakn   |
     When for each session, open transactions of type:
       | write   |
@@ -149,10 +149,10 @@ Feature: Connection Transaction
       | write   |
 
   @ignore-grakn-core
-  Scenario: one keyspace, one session, many transactions to read and write
-    When connection create keyspace:
+  Scenario: one database, one session, many transactions to read and write
+    When connection create database:
       | grakn   |
-    Given connection open session for keyspace:
+    Given connection open session for database:
       | grakn   |
     When for each session, open transactions of type:
       | read    |
@@ -183,10 +183,10 @@ Feature: Connection Transaction
       | read    |
       | write   |
 
-  Scenario: one keyspace, one session, many transactions in parallel to read
-    When connection create keyspace:
+  Scenario: one database, one session, many transactions in parallel to read
+    When connection create database:
       | grakn   |
-    Given connection open session for keyspace:
+    Given connection open session for database:
       | grakn   |
     When for each session, open transactions in parallel of type:
       | read    |
@@ -217,10 +217,10 @@ Feature: Connection Transaction
       | read    |
       | read    |
 
-  Scenario: one keyspace, one session, many transactions in parallel to write
-    When connection create keyspace:
+  Scenario: one database, one session, many transactions in parallel to write
+    When connection create database:
       | grakn   |
-    Given connection open session for keyspace:
+    Given connection open session for database:
       | grakn   |
     When for each session, open transactions in parallel of type:
       | write   |
@@ -251,10 +251,10 @@ Feature: Connection Transaction
       | write   |
       | write   |
 
-  Scenario: one keyspace, one session, many transactions in parallel to read and write
-    When connection create keyspace:
+  Scenario: one database, one session, many transactions in parallel to read and write
+    When connection create database:
       | grakn   |
-    Given connection open session for keyspace:
+    Given connection open session for database:
       | grakn   |
     When for each session, open transactions in parallel of type:
       | read    |
@@ -285,10 +285,10 @@ Feature: Connection Transaction
       | read    |
       | write   |
 
-  Scenario: one keyspace, many sessions, one transaction to read
-    When connection create keyspace:
+  Scenario: one database, many sessions, one transaction to read
+    When connection create database:
       | grakn   |
-    Given connection open sessions for keyspace:
+    Given connection open sessions for database:
       | grakn   |
       | grakn   |
       | grakn   |
@@ -308,10 +308,10 @@ Feature: Connection Transaction
     Then for each session, transaction has type:
       | read    |
 
-  Scenario: one keyspace, many sessions, one transaction to write
-    When connection create keyspace:
+  Scenario: one database, many sessions, one transaction to write
+    When connection create database:
       | grakn   |
-    Given connection open sessions for keyspace:
+    Given connection open sessions for database:
       | grakn   |
       | grakn   |
       | grakn   |
@@ -332,10 +332,10 @@ Feature: Connection Transaction
       | write   |
 
   @ignore-grakn-core
-  Scenario: one keyspace, many sessions, many transactions to read
-    When connection create keyspace:
+  Scenario: one database, many sessions, many transactions to read
+    When connection create database:
       | grakn   |
-    Given connection open sessions for keyspace:
+    Given connection open sessions for database:
       | grakn   |
       | grakn   |
       | grakn   |
@@ -378,10 +378,10 @@ Feature: Connection Transaction
       | read    |
 
   @ignore-grakn-core
-  Scenario: one keyspace, many sessions, many transactions to write
-    When connection create keyspace:
+  Scenario: one database, many sessions, many transactions to write
+    When connection create database:
       | grakn   |
-    Given connection open sessions for keyspace:
+    Given connection open sessions for database:
       | grakn   |
       | grakn   |
       | grakn   |
@@ -424,10 +424,10 @@ Feature: Connection Transaction
       | write   |
 
   @ignore-grakn-core
-  Scenario: one keyspace, many sessions, many transactions to read and write
-    When connection create keyspace:
+  Scenario: one database, many sessions, many transactions to read and write
+    When connection create database:
       | grakn   |
-    Given connection open sessions for keyspace:
+    Given connection open sessions for database:
       | grakn   |
       | grakn   |
       | grakn   |
@@ -469,10 +469,10 @@ Feature: Connection Transaction
       | read    |
       | write   |
 
-  Scenario: one keyspace, many sessions, many transactions in parallel to read
-    When connection create keyspace:
+  Scenario: one database, many sessions, many transactions in parallel to read
+    When connection create database:
       | grakn   |
-    Given connection open sessions for keyspace:
+    Given connection open sessions for database:
       | grakn   |
       | grakn   |
       | grakn   |
@@ -514,10 +514,10 @@ Feature: Connection Transaction
       | read    |
       | read    |
 
-  Scenario: one keyspace, many sessions, many transactions in parallel to write
-    When connection create keyspace:
+  Scenario: one database, many sessions, many transactions in parallel to write
+    When connection create database:
       | grakn   |
-    Given connection open sessions for keyspace:
+    Given connection open sessions for database:
       | grakn   |
       | grakn   |
       | grakn   |
@@ -559,10 +559,10 @@ Feature: Connection Transaction
       | write   |
       | write   |
 
-  Scenario: one keyspace, many sessions, many transactions in parallel to read and write
-    When connection create keyspace:
+  Scenario: one database, many sessions, many transactions in parallel to read and write
+    When connection create database:
       | grakn   |
-    Given connection open sessions for keyspace:
+    Given connection open sessions for database:
       | grakn   |
       | grakn   |
       | grakn   |
@@ -604,16 +604,16 @@ Feature: Connection Transaction
       | read    |
       | write   |
 
-#  Scenario: one keyspace, many sessions in parallel, one transactions to read
+#  Scenario: one database, many sessions in parallel, one transactions to read
 #
-#  Scenario: one keyspace, many sessions in parallel, one transactions to write
+#  Scenario: one database, many sessions in parallel, one transactions to write
 #
-#  Scenario: one keyspace, many sessions in parallel, many transactions to read
+#  Scenario: one database, many sessions in parallel, many transactions to read
 #
-#  Scenario: one keyspace, many sessions in parallel, many transactions to write
+#  Scenario: one database, many sessions in parallel, many transactions to write
 #
-#  Scenario: one keyspace, many sessions in parallel, many transactions in parallel to read
+#  Scenario: one database, many sessions in parallel, many transactions in parallel to read
 #
-#  Scenario: one keyspace, many sessions in parallel, many transactions in parallel to write
+#  Scenario: one database, many sessions in parallel, many transactions in parallel to write
 
 

--- a/behaviour/graql/explanation/language.feature
+++ b/behaviour/graql/explanation/language.feature
@@ -19,8 +19,8 @@ Feature: Graql Reasoning Explanation
 
   Background: Initialise a session and transaction for each scenario
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection open sessions for keyspaces:
+    Given connection delete all databases
+    Given connection open sessions for databases:
       | test_explanation |
     Given transaction is initialised
 

--- a/behaviour/graql/explanation/reasoner.feature
+++ b/behaviour/graql/explanation/reasoner.feature
@@ -21,8 +21,8 @@ Feature: Graql Reasoning Explanation
 
   Background: Initialise a session and transaction for each scenario
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection open sessions for keyspaces:
+    Given connection delete all databases
+    Given connection open sessions for databases:
       | test_explanation |
     Given transaction is initialised
 

--- a/behaviour/graql/language/define.feature
+++ b/behaviour/graql/language/define.feature
@@ -18,8 +18,8 @@ Feature: Graql Define Query
 
   Background: Open connection and create a simple extensible schema
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection open sessions for keyspaces:
+    Given connection delete all databases
+    Given connection open sessions for databases:
       | test_define |
     Given transaction is initialised
     Given the integrity is validated

--- a/behaviour/graql/language/delete.feature
+++ b/behaviour/graql/language/delete.feature
@@ -18,8 +18,8 @@ Feature: Graql Delete Query
 
   Background: Open connection and create a simple extensible schema
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection open sessions for keyspaces:
+    Given connection delete all databases
+    Given connection open sessions for databases:
       | test_delete |
     Given transaction is initialised
     Given graql define

--- a/behaviour/graql/language/get.feature
+++ b/behaviour/graql/language/get.feature
@@ -18,8 +18,8 @@ Feature: Graql Get Query
 
   Background: Open connection and create a simple extensible schema
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection open sessions for keyspaces:
+    Given connection delete all databases
+    Given connection open sessions for databases:
       | test_get |
     Given transaction is initialised
     Given graql define

--- a/behaviour/graql/language/insert.feature
+++ b/behaviour/graql/language/insert.feature
@@ -18,8 +18,8 @@ Feature: Graql Insert Query
 
   Background: Open connection
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection open sessions for keyspaces:
+    Given connection delete all databases
+    Given connection open sessions for databases:
       | test_insert |
     Given transaction is initialised
     Given the integrity is validated

--- a/behaviour/graql/language/match.feature
+++ b/behaviour/graql/language/match.feature
@@ -18,8 +18,8 @@ Feature: Graql Match Clause
 
   Background: Open connection
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection open sessions for keyspaces:
+    Given connection delete all databases
+    Given connection open sessions for databases:
       | test_match |
     Given transaction is initialised
     Given graql define

--- a/behaviour/graql/language/rule-validation.feature
+++ b/behaviour/graql/language/rule-validation.feature
@@ -19,8 +19,8 @@ Feature: Graql Rule Validation
 
   Background: Initialise a session and transaction for each scenario
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection open sessions for keyspaces:
+    Given connection delete all databases
+    Given connection open sessions for databases:
       | test_rule_validation |
     Given transaction is initialised
 

--- a/behaviour/graql/language/undefine.feature
+++ b/behaviour/graql/language/undefine.feature
@@ -18,8 +18,8 @@ Feature: Graql Undefine Query
 
   Background: Open connection and create a simple extensible schema
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection open sessions for keyspaces:
+    Given connection delete all databases
+    Given connection open sessions for databases:
       | test_undefine |
     Given transaction is initialised
     Given the integrity is validated

--- a/behaviour/graql/reasoner/attribute-attachment.feature
+++ b/behaviour/graql/reasoner/attribute-attachment.feature
@@ -17,15 +17,15 @@
 
 Feature: Attribute Attachment Resolution
 
-  Background: Set up keyspaces for resolution testing
+  Background: Set up databases for resolution testing
 
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection open sessions for keyspaces:
+    Given connection delete all databases
+    Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised keyspace is named: materialised
-    Given reasoned keyspace is named: reasoned
+    Given materialised database is named: materialised
+    Given reasoned database is named: reasoned
     Given for each session, graql define
       """
       define
@@ -80,20 +80,20 @@ Feature: Attribute Attachment Resolution
       $geX isa person, has string-attribute "banana";
       $geY isa person;
       """
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Then for graql query
       """
       match $x isa person, has string-attribute $y; get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 2
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 2
     Then for graql query
       """
       match $x isa string-attribute; get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
-#    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
+#    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps once re-attachment of unrelated attributes is resolvable
@@ -132,21 +132,21 @@ Feature: Attribute Attachment Resolution
       $geX isa person, has string-attribute "banana";
       $geY isa person;
       """
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Then for graql query
       """
       match $x isa person; get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 2
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 2
     Then for graql query
       """
       match $x isa person, has attribute $y; get;
       """
     # four attributes for each entity
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 6
-#    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 6
+#    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps once re-attachment of unrelated attributes is resolvable
@@ -167,27 +167,27 @@ Feature: Attribute Attachment Resolution
       insert
       $geX isa person, has string-attribute "banana";
       """
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Then for graql query
       """
       match $x isa person, has sub-string-attribute $y; get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
     Then for graql query
       """
       match $x isa sub-string-attribute; get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
     Then for graql query
       """
       match $x isa string-attribute; $y isa sub-string-attribute; get;
       """
     # 2 SA instances - one base, one sub hence two answers
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 2
-#    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 2
+#    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps once re-attachment of unrelated attributes is resolvable
@@ -209,20 +209,20 @@ Feature: Attribute Attachment Resolution
       $geX isa person, has string-attribute "banana";
       $geY isa person;
       """
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Then for graql query
       """
       match $x isa person, has unrelated-attribute $y; get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
     Then for graql query
       """
       match $x isa unrelated-attribute; get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
-#    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
+#    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps once attribute re-attachment is resolvable
@@ -255,14 +255,14 @@ Feature: Attribute Attachment Resolution
       $geY isa person;
       (leader:$geX, team-member:$geX) isa team;
       """
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Then for graql query
       """
       match $x has string-attribute $y; get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 3
-#    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 3
+#    Then materialised and reasoned databases are the same size
 
 
   Scenario: a rule can infer an attribute value that did not previously exist in the graph
@@ -294,26 +294,26 @@ Feature: Attribute Attachment Resolution
       $aeY isa soft-drink;
       $r "Ocado" isa retailer;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match $x has retailer 'Ocado'; get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 2
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 2
     Then for graql query
       """
       match $x has retailer $r; get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 4
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 4
     Then for graql query
       """
       match $x has retailer 'Tesco'; get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 2
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 2
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: a rule can make a thing own an attribute that had no prior owners
@@ -337,11 +337,11 @@ Feature: Attribute Attachment Resolution
       $aeY isa soft-drink;
       $r "Ocado" isa retailer;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match $x isa soft-drink, has retailer 'Ocado'; get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 2
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 2
+    Then materialised and reasoned databases are the same size

--- a/behaviour/graql/reasoner/concept-inequality.feature
+++ b/behaviour/graql/reasoner/concept-inequality.feature
@@ -18,15 +18,15 @@
 # TODO: re-enable all steps in file when 3-hop transitivity is resolvable
 Feature: Concept Inequality Resolution
 
-  Background: Set up keyspaces for resolution testing
+  Background: Set up databases for resolution testing
 
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection open sessions for keyspaces:
+    Given connection delete all databases
+    Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised keyspace is named: materialised
-    Given reasoned keyspace is named: reasoned
+    Given materialised database is named: materialised
+    Given reasoned database is named: reasoned
     Given for each session, graql define
       """
       define
@@ -115,32 +115,32 @@ Feature: Concept Inequality Resolution
       (related-state: $s1) isa achieved;
       (related-state: $s2) isa achieved;
       """
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Then for graql query
       """
       match (related-state: $s) isa holds; get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
     Then answer set is equivalent for graql query
       """
       match $s isa state, has name 's2'; get;
       """
-#    Then materialised and reasoned keyspaces are the same size
+#    Then materialised and reasoned databases are the same size
 
 
   Scenario: inferred binary relations can be filtered by concept inequality of their roleplayers
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Given for graql query
       """
       match
         (ball1: $x, ball2: $y) isa selection;
       get;
       """
-#    Given all answers are correct in reasoned keyspace
+#    Given all answers are correct in reasoned database
     # materialised: [ab, ba, bc, cb]
     # inferred: [aa, ac, bb, ca, cc]
-    Given answer size in reasoned keyspace is: 9
+    Given answer size in reasoned database is: 9
     Then for graql query
       """
       match
@@ -148,10 +148,10 @@ Feature: Concept Inequality Resolution
         $x != $y;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # materialised: [ab, ba, bc, cb]
     # inferred: [ac, ca]
-    Then answer size in reasoned keyspace is: 6
+    Then answer size in reasoned database is: 6
     # verify that the answer pairs to the previous query have distinct names within each pair
     Then for graql query
       """
@@ -163,13 +163,13 @@ Feature: Concept Inequality Resolution
         $nx !== $ny;
       get $x, $y;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 6
-#    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 6
+#    Then materialised and reasoned databases are the same size
 
 
   Scenario: inferred binary relations can be filtered by inequality to a specific concept
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Then for graql query
       """
       match
@@ -178,8 +178,8 @@ Feature: Concept Inequality Resolution
         $y has name 'c';
       get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 2
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 2
     # verify answers are [ac, bc]
     Then for graql query
       """
@@ -190,9 +190,9 @@ Feature: Concept Inequality Resolution
         {$x has name 'a';} or {$x has name 'b';};
       get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 2
-#    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 2
+#    Then materialised and reasoned databases are the same size
 
 
   Scenario: pairs of inferred relations can be filtered by inequality of players in the same role
@@ -206,7 +206,7 @@ Feature: Concept Inequality Resolution
                 v     v
                y  !=   z
 
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Then for graql query
       """
       match
@@ -215,11 +215,11 @@ Feature: Concept Inequality Resolution
         $y != $z;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # [aab, aac, aba, abc, aca, acb,
     #  bab, bac, bba, bbc, bca, bcb,
     #  cab, cac, cba, cbc, cca, ccb]
-    Then answer size in reasoned keyspace is: 18
+    Then answer size in reasoned database is: 18
     # verify that $y and $z always have distinct names
     Then for graql query
       """
@@ -232,9 +232,9 @@ Feature: Concept Inequality Resolution
         $ny !== $nz;
       get $x, $y, $z;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 18
-#    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 18
+#    Then materialised and reasoned databases are the same size
 
 
 
@@ -250,7 +250,7 @@ Feature: Concept Inequality Resolution
                       /     v
                      x  !=   z
 
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Then for graql query
       """
       match
@@ -259,8 +259,8 @@ Feature: Concept Inequality Resolution
         $x != $z;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 18
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 18
     # verify that $y and $z always have distinct names
     Then for graql query
       """
@@ -273,9 +273,9 @@ Feature: Concept Inequality Resolution
         $nx !== $nz;
       get $x, $y, $z;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 18
-#    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 18
+#    Then materialised and reasoned databases are the same size
 
 
   Scenario: inequality predicates can operate independently against multiple pairs of relations in the same query
@@ -293,7 +293,7 @@ Feature: Concept Inequality Resolution
                    v        v
                  y2    !=    z2
 
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Given for graql query
       """
       match
@@ -303,9 +303,9 @@ Feature: Concept Inequality Resolution
         (ball1: $x, ball2: $z2) isa selection;
       get;
       """
-#    Given all answers are correct in reasoned keyspace
+#    Given all answers are correct in reasoned database
     # For each of the [3] values of $x, there are 3^4 = 81 choices for {$y1, $z1, $y2, $z2}, for a total of 243
-    Given answer size in reasoned keyspace is: 243
+    Given answer size in reasoned database is: 243
     Then for graql query
       """
       match
@@ -318,9 +318,9 @@ Feature: Concept Inequality Resolution
         $y2 != $z2;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # Each neq predicate reduces the answer size by 1/3, cutting it to 162, then 108
-    Then answer size in reasoned keyspace is: 108
+    Then answer size in reasoned database is: 108
     # verify that $y1 and $z1 - as well as $y2 and $z2 - always have distinct names
     Then for graql query
       """
@@ -339,9 +339,9 @@ Feature: Concept Inequality Resolution
         $ny2 !== $nz2;
       get $x, $y1, $z1, $y2, $z2;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 108
-#    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 108
+#    Then materialised and reasoned databases are the same size
 
 
   Scenario: inequality predicates can operate independently against multiple roleplayers in the same relation
@@ -355,7 +355,7 @@ Feature: Concept Inequality Resolution
                   v
                   y     - != - >  z2
 
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Given for graql query
       """
       match
@@ -364,9 +364,9 @@ Feature: Concept Inequality Resolution
         (ball1: $y, ball2: $z2) isa selection;
       get;
       """
-#    Given all answers are correct in reasoned keyspace
+#    Given all answers are correct in reasoned database
     # There are 3^4 possible choices for the set {$x, $y, $z1, $z2}, for a total of 81
-    Given answer size in reasoned keyspace is: 81
+    Given answer size in reasoned database is: 81
     Then for graql query
       """
       match
@@ -378,9 +378,9 @@ Feature: Concept Inequality Resolution
         $y != $z2;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # Each neq predicate reduces the answer size by 1/3, cutting it to 54, then 36
-    Then answer size in reasoned keyspace is: 36
+    Then answer size in reasoned database is: 36
     # verify that $y1 and $z1 - as well as $y2 and $z2 - always have distinct names
     Then for graql query
       """
@@ -398,9 +398,9 @@ Feature: Concept Inequality Resolution
         $ny !== $nz2;
       get $x, $y, $z1, $z2;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 36
-#    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 36
+#    Then materialised and reasoned databases are the same size
 
 
   @ignore
@@ -434,7 +434,7 @@ Feature: Concept Inequality Resolution
       $x isa person, has string-attribute "Tesco";
       $y isa soft-drink, has name "Tesco";
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
@@ -445,7 +445,7 @@ Feature: Concept Inequality Resolution
         $typeof_ax != $typeof_ay;
       get;
       """
-    Then all answers are correct in reasoned keyspace
+    Then all answers are correct in reasoned database
     # x   | ax  | y   | ay  |
     # PER | STA | SOF | NAM |
     # PER | STA | SOF | RET |
@@ -453,8 +453,8 @@ Feature: Concept Inequality Resolution
     # SOF | RET | PER | STA |
     # SOF | NAM | SOF | STA |
     # SOF | STA | SOF | NAM |
-    Then answer size in reasoned keyspace is: 6
-    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 6
+    Then materialised and reasoned databases are the same size
 
   @ignore
   # TODO: re-enable once grakn#5821 is fixed
@@ -507,7 +507,7 @@ Feature: Concept Inequality Resolution
       $y isa soft-drink, has name "Sprite";
       $z "Ocado" isa retailer;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
@@ -521,8 +521,8 @@ Feature: Concept Inequality Resolution
         $unwantedType type string-attribute;
       get $x, $value, $type;
       """
-    Then all answers are correct in reasoned keyspace
+    Then all answers are correct in reasoned database
     # x      | value | type     |
     # Sprite | Tesco | retailer |
-    Then answer size in reasoned keyspace is: 1
-#    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 1
+#    Then materialised and reasoned databases are the same size

--- a/behaviour/graql/reasoner/negation.feature
+++ b/behaviour/graql/reasoner/negation.feature
@@ -17,15 +17,15 @@
 
 Feature: Negation Resolution
 
-  Background: Set up keyspaces for resolution testing
+  Background: Set up databases for resolution testing
 
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection open sessions for keyspaces:
+    Given connection delete all databases
+    Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised keyspace is named: materialised
-    Given reasoned keyspace is named: reasoned
+    Given materialised database is named: materialised
+    Given reasoned database is named: reasoned
     Given for each session, graql define
       """
       define
@@ -80,19 +80,19 @@ Feature: Negation Resolution
       $x isa person, has age 10;
       $y isa person, has age 20;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match $x has name "Not Ten", has age 20; get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
     Then for graql query
       """
       match $x has name "Not Ten", has age 10; get;
       """
-    Then answer size in reasoned keyspace is: 0
-    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 0
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: a negation with a roleplayer but no relation variable checks that no relations have that roleplayer
@@ -127,7 +127,7 @@ Feature: Negation Resolution
       $z isa person, has name "Edward";
       $c isa company, has name "Apple";
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
@@ -135,10 +135,10 @@ Feature: Negation Resolution
         not {(manager: $x) isa employment;};
       get;
       """
-    Then all answers are correct in reasoned keyspace
+    Then all answers are correct in reasoned database
     # Anna is not retrieved because she is someone's manager
-    Then answer size in reasoned keyspace is: 2
-    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 2
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: a negation with a roleplayer and relation variable checks that the relation doesn't have that roleplayer
@@ -173,7 +173,7 @@ Feature: Negation Resolution
       $z isa person, has name "Edward";
       $c isa company, has name "Apple";
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
@@ -181,10 +181,10 @@ Feature: Negation Resolution
         not {$r (manager: $x) isa employment;};
       get;
       """
-    Then all answers are correct in reasoned keyspace
+    Then all answers are correct in reasoned database
     # Anna is retrieved because she is not a manager in her own employee-employment relation
-    Then answer size in reasoned keyspace is: 3
-    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 3
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: a negation with unbound roleplayer variables checks that the relation doesn't have any player for that role
@@ -219,7 +219,7 @@ Feature: Negation Resolution
       $z isa person, has name "Edward";
       $c isa company, has name "Apple";
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
@@ -227,9 +227,9 @@ Feature: Negation Resolution
         not {$r (manager: $z) isa employment;};
       get;
       """
-    Then all answers are correct in reasoned keyspace
+    Then all answers are correct in reasoned database
     # Carol is not retrieved because her employment relation has a manager
-    Then answer size in reasoned keyspace is: 2
+    Then answer size in reasoned database is: 2
     Then for graql query
       """
       match
@@ -238,6 +238,6 @@ Feature: Negation Resolution
       get;
       """
     # Now the negation block is harder to fulfil. Carol is not her own manager, so she is retrieved again
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 3
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 3
+    Then materialised and reasoned databases are the same size

--- a/behaviour/graql/reasoner/relation-inference.feature
+++ b/behaviour/graql/reasoner/relation-inference.feature
@@ -17,15 +17,15 @@
 
 Feature: Relation Inference Resolution
 
-  Background: Set up keyspaces for resolution testing
+  Background: Set up databases for resolution testing
 
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection open sessions for keyspaces:
+    Given connection delete all databases
+    Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised keyspace is named: materialised
-    Given reasoned keyspace is named: reasoned
+    Given materialised database is named: materialised
+    Given reasoned database is named: reasoned
     Given for each session, graql define
       """
       define
@@ -82,7 +82,7 @@ Feature: Relation Inference Resolution
       $y isa dog;
       $z isa person;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
@@ -90,8 +90,8 @@ Feature: Relation Inference Resolution
         ($x) isa employment;
       get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 2
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 2
     Then for graql query
       """
       match
@@ -99,8 +99,8 @@ Feature: Relation Inference Resolution
         ($x) isa employment;
       get;
       """
-    Then answer size in reasoned keyspace is: 0
-    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 0
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: a relation can be inferred based on an attribute ownership
@@ -120,7 +120,7 @@ Feature: Relation Inference Resolution
       $x isa person, has name "Haikal";
       $y isa person, has name "Michael";
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
@@ -128,8 +128,8 @@ Feature: Relation Inference Resolution
         ($x) isa employment;
       get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
     Then for graql query
       """
       match
@@ -137,8 +137,8 @@ Feature: Relation Inference Resolution
         ($x) isa employment;
       get;
       """
-    Then answer size in reasoned keyspace is: 0
-    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 0
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: a rule can infer a relation with an attribute as a roleplayer
@@ -162,7 +162,7 @@ Feature: Relation Inference Resolution
       $x isa item, has name "3kg jar of Nutella";
       $y 14.99 isa price;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
@@ -172,9 +172,9 @@ Feature: Relation Inference Resolution
         $p 14.99 isa price;
       get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: a rule can infer a relation based on ownership of any instance of a specific attribute type
@@ -200,7 +200,7 @@ Feature: Relation Inference Resolution
       $p2 isa person, has name "Prasanth";
       $y 1664 isa year;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
@@ -208,9 +208,9 @@ Feature: Relation Inference Resolution
         ($x, employee: $p, employer: $y) isa employment;
       get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 2
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 2
+    Then materialised and reasoned databases are the same size
 
 
   ###############
@@ -239,18 +239,18 @@ Feature: Relation Inference Resolution
       $d isa person, has name "Damien";
       $e isa person, has name "Eustace";
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match $r isa friendship; get;
       """
-    Then all answers are correct in reasoned keyspace
+    Then all answers are correct in reasoned database
     # When there is 1 concept we have {aa}.
     # Adding a 2nd concept gives us 2 new relations - where each relation contains b, and one other concept (a or b).
     # Adding a 3rd concept gives us 3 new relations - where each relation contains c, and one other concept (a, b or c).
     # Generally, the total number of relations is the sum of all integers from 1 to n inclusive.
-    Then answer size in reasoned keyspace is: 15
-    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 15
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: when matching all possible pairs inferred from n concepts, the answer size is the square of n
@@ -274,15 +274,15 @@ Feature: Relation Inference Resolution
       $d isa person, has name "Damien";
       $e isa person, has name "Eustace";
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match ($x, $y) isa friendship; get;
       """
-    Then all answers are correct in reasoned keyspace
+    Then all answers are correct in reasoned database
     # Here there are n choices for x, and n choices for y, so the total answer size is n^2
-    Then answer size in reasoned keyspace is: 25
-    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 25
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: when a relation is reflexive, matching concepts are related to themselves
@@ -304,16 +304,16 @@ Feature: Relation Inference Resolution
       $g isa person, has name "Gawain";
       $h isa person, has name "Hattie";
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
         (employee: $x, employer: $x) isa employment;
       get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 3
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 3
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: inferred reflexive relations can be retrieved using multiple variables to refer to the same concept
@@ -333,16 +333,16 @@ Feature: Relation Inference Resolution
       insert
       $i isa person, has name "Irma";
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
         (employee: $x, employer: $y) isa employment;
       get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: inferred relations between distinct concepts are not retrieved when matching concepts related to themselves
@@ -364,15 +364,15 @@ Feature: Relation Inference Resolution
       $r isa person, has name "Robert";
       $j isa person, has name "Jane";
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
         (employee: $x, employer: $x) isa employment;
       get;
       """
-    Then answer size in reasoned keyspace is: 0
-    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 0
+    Then materialised and reasoned databases are the same size
 
 
   ############
@@ -429,28 +429,28 @@ Feature: Relation Inference Resolution
       (robot-pet: $a, robot-pet-owner: $b) isa robot-pet-ownership;
       (coworker: $b, coworker: $c) isa coworkers;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
         (coworker: $x, coworker: $x) isa coworkers;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # (p,p) is a coworkers since people work with themselves.
     # Applying the robot work rule we see that (r1,p) is a pet ownership, and (p,p) and (p,r2) are coworker relations,
     # so (r1,p) and (r1,r2) are both coworker relations.
     # Coworker relations are symmetric, so (r2,p), (p,r1) and (r2,r1) are all coworker relations.
     # Applying the robot work rule a 2nd time, (r1,p) is a pet ownership and (p,r1) are coworkers,
     # therefore (r1,r1) is a reflexive coworker relation. So the answers are [p] and [r1].
-    Then answer size in reasoned keyspace is: 2
+    Then answer size in reasoned database is: 2
     Then for graql query
       """
       match
         (coworker: $x, coworker: $y) isa coworkers;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # $x | $y |
     # p  | p  |
     # p  | r2 |
@@ -460,8 +460,8 @@ Feature: Relation Inference Resolution
     # p  | r1 |
     # r2 | r1 |
     # r1 | r1 |
-    Then answer size in reasoned keyspace is: 8
-    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 8
+    Then materialised and reasoned databases are the same size
 
 
   ################
@@ -489,14 +489,14 @@ Feature: Relation Inference Resolution
       (location-subordinate: $x, location-superior: $y) isa location-hierarchy;
       (location-subordinate: $y, location-superior: $y) isa location-hierarchy;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match $x isa location-hierarchy; get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 3
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 3
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when 3-hop transitivity is resolvable
@@ -524,15 +524,15 @@ Feature: Relation Inference Resolution
       (location-subordinate: $b, location-superior: $c) isa location-hierarchy;
       (location-subordinate: $c, location-superior: $d) isa location-hierarchy;
       """
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Then for graql query
       """
       match (location-subordinate: $x1, location-superior: $x2) isa location-hierarchy; get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 6
-    Then answers are consistent across 5 executions in reasoned keyspace
-#    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 6
+    Then answers are consistent across 5 executions in reasoned database
+#    Then materialised and reasoned databases are the same size
 
 
   Scenario: when a transitive rule's `then` matches a query, but its `when` is unmet, the material answers are returned
@@ -586,14 +586,14 @@ Feature: Relation Inference Resolution
 
       (location-subordinate: $x3, location-superior: $x4) isa location-hierarchy;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match (location-subordinate: $x, location-superior: $y) isa location-hierarchy; get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
+    Then materialised and reasoned databases are the same size
 
 
   #######################
@@ -618,13 +618,13 @@ Feature: Relation Inference Resolution
       $x isa person;
       $c isa company;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match (employee: $x, employee: $y) isa employment; get;
       """
-    Then answer size in reasoned keyspace is: 0
-    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 0
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: a relation with two roleplayers inferred by the same rule is retrieved when matching only one of the roles
@@ -645,14 +645,14 @@ Feature: Relation Inference Resolution
       $x isa person;
       $c isa company;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match (employee: $x) isa employment; get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: when matching an inferred relation with repeated roles, answers contain all permutations of the roleplayers
@@ -675,22 +675,22 @@ Feature: Relation Inference Resolution
       $y isa person, has name "Bob";
       $z isa person, has name "Charlie";
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
         (friend: $a, friend: $b, friend: $c) isa friendship;
       get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 6
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 6
     Then answer set is equivalent for graql query
       """
       match
         $r (friend: $a, friend: $b, friend: $c) isa friendship;
       get $a, $b, $c;
       """
-    Then materialised and reasoned keyspaces are the same size
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when fixed (#75), currently they are very slow
@@ -724,7 +724,7 @@ Feature: Relation Inference Resolution
       (choice1: $x, choice2: $y) isa selection;
       (choice1: $y, choice2: $z) isa selection;
       """
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Then for graql query
       """
       match
@@ -733,9 +733,9 @@ Feature: Relation Inference Resolution
         $y has name $n;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # (a,a), (b,b), (c,c)
-    Then answer size in reasoned keyspace is: 3
+    Then answer size in reasoned database is: 3
     Then for graql query
       """
       match
@@ -745,8 +745,8 @@ Feature: Relation Inference Resolution
         $n == 'a';
       get $x, $y;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
     Then answer set is equivalent for graql query
       """
       match
@@ -755,7 +755,7 @@ Feature: Relation Inference Resolution
         $y has name 'a';
       get;
       """
-#    Then materialised and reasoned keyspaces are the same size
+#    Then materialised and reasoned databases are the same size
 
 
   #######################
@@ -785,7 +785,7 @@ Feature: Relation Inference Resolution
       (location-subordinate: $x, location-superior: $y) isa location-hierarchy;
       (location-subordinate: $y, location-superior: $z) isa location-hierarchy;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
@@ -795,10 +795,10 @@ Feature: Relation Inference Resolution
         ($b, $c);
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # $c in {'Turku Airport', 'Finland'}
-    Then answer size in reasoned keyspace is: 2
-    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 2
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when fixed (#75)
@@ -824,7 +824,7 @@ Feature: Relation Inference Resolution
       (location-subordinate: $x, location-superior: $y) isa location-hierarchy;
       (location-subordinate: $y, location-superior: $z) isa location-hierarchy;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Given for graql query
       """
       match
@@ -833,8 +833,8 @@ Feature: Relation Inference Resolution
         $b isa place, has name "Turku";
       get;
       """
-#    Given all answers are correct in reasoned keyspace
-    Given answer size in reasoned keyspace is: 1
+#    Given all answers are correct in reasoned database
+    Given answer size in reasoned database is: 1
     Then for graql query
       """
       match
@@ -844,10 +844,10 @@ Feature: Relation Inference Resolution
         ($c, $d);
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # (2 db relations + 1 inferred) x 2 for variable swap
-    Then answer size in reasoned keyspace is: 6
-    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 6
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when fixed (#75)
@@ -885,22 +885,22 @@ Feature: Relation Inference Resolution
       (location-subordinate: $x, location-superior: $y) isa location-hierarchy;
       (location-subordinate: $y, location-superior: $z) isa location-hierarchy;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Given for graql query
       """
       match
         ($a, $b) isa relation;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # Despite there being more inferred relations, the answer size is still 6 (as in the previous scenario)
     # because the query is only interested in the related concepts, not in the relation instances themselves
-    Then answer size in reasoned keyspace is: 6
+    Then answer size in reasoned database is: 6
     Then answer set is equivalent for graql query
       """
       match ($a, $b); get;
       """
-#    Then materialised and reasoned keyspaces are the same size
+#    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when fixed (#75)
@@ -926,7 +926,7 @@ Feature: Relation Inference Resolution
       (location-subordinate: $x, location-superior: $y) isa location-hierarchy;
       (location-subordinate: $y, location-superior: $z) isa location-hierarchy;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
@@ -934,7 +934,7 @@ Feature: Relation Inference Resolution
         ($b, $c);
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # a   | b   | c   |
     # AIR | TUR | FIN |
     # AIR | FIN | TUR |
@@ -948,8 +948,8 @@ Feature: Relation Inference Resolution
     # FIN | TUR | AIR |
     # FIN | AIR | FIN |
     # FIN | TUR | FIN |
-    Then answer size in reasoned keyspace is: 12
-    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 12
+    Then materialised and reasoned databases are the same size
 
 
   #####################
@@ -997,14 +997,14 @@ Feature: Relation Inference Resolution
       (location-subordinate: $x, location-superior: $y) isa location-hierarchy;
       (location-subordinate: $y, location-superior: $z) isa location-hierarchy;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match (big-location-subordinate: $x, big-location-superior: $y) isa big-location-hierarchy; get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
-    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when resolvable (currently takes too long)
@@ -1071,14 +1071,14 @@ Feature: Relation Inference Resolution
       (role21:$v, role22:$w) isa relation2;
       (role11:$w, role12:$q) isa relation1;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match (role31: $x, role32: $y) isa relation3; get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
-    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: circular rule dependencies can be resolved
@@ -1140,22 +1140,22 @@ Feature: Relation Inference Resolution
       (role11:$x, role12:$x) isa relation1;
       (role11:$x, role12:$y) isa relation1;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match (role31: $x, role32: $y) isa relation3; get;
       """
-    Then all answers are correct in reasoned keyspace
+    Then all answers are correct in reasoned database
     # Each of the two material relation1 instances should infer a single relation3 via 1-to-2 and 2-to-3
-    Then answer size in reasoned keyspace is: 2
+    Then answer size in reasoned database is: 2
     Then for graql query
       """
       match (role21: $x, role22: $y) isa relation2; get;
       """
-    Then all answers are correct in reasoned keyspace
+    Then all answers are correct in reasoned database
     # Relation-3-to-2 should not make any additional inferences - it should merely assert that the relations exist
-    Then answer size in reasoned keyspace is: 2
-    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 2
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when we have a solution for materialisation of infinite graphs (#75)
@@ -1186,14 +1186,14 @@ Feature: Relation Inference Resolution
       # If only Yusuf didn't dream about himself...
       (dreamer: $x, dream-subject: $x) isa dream;
       """
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Then for graql query
       """
       match $x isa dream; get; limit 10;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 10
-#    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 10
+#    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when materialisation is possible (may be an infinite graph?) (#75)
@@ -1289,17 +1289,17 @@ Feature: Relation Inference Resolution
       (supertype: $f, subtype: $rr) isa inheritance;
       (supertype: $f, subtype: $rr2) isa inheritance;
       """
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Then for graql query
       """
       match $p isa pair, has name 'ff'; get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 16
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 16
     Then for graql query
       """
       match $p isa pair; get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 64
-#    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 64
+#    Then materialised and reasoned databases are the same size

--- a/behaviour/graql/reasoner/resolution-test-framework.feature
+++ b/behaviour/graql/reasoner/resolution-test-framework.feature
@@ -17,15 +17,15 @@
 
 Feature: Resolution Test Framework
 
-  Background: Set up keyspaces for resolution testing
+  Background: Set up databases for resolution testing
 
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection open sessions for keyspaces:
+    Given connection delete all databases
+    Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised keyspace is named: materialised
-    Given reasoned keyspace is named: reasoned
+    Given materialised database is named: materialised
+    Given reasoned database is named: reasoned
 
 
   Scenario: basic rule
@@ -50,13 +50,13 @@ Feature: Resolution Test Framework
       insert
       $x isa company;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match $co has name $n; get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: compounding rules
@@ -94,13 +94,13 @@ Feature: Resolution Test Framework
       $co isa company;
       """
 
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match $co has is-liable $l; get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: 2-hop transitivity
@@ -143,7 +143,7 @@ Feature: Resolution Test Framework
       (superior: $cit, subordinate: $ar) isa location-hierarchy;
       """
 
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
@@ -151,8 +151,8 @@ Feature: Resolution Test Framework
       (superior: $l, subordinate: $k) isa location-hierarchy;
       get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then materialised and reasoned databases are the same size
 
 
   @ignore
@@ -202,15 +202,15 @@ Feature: Resolution Test Framework
       (location-hierarchy_superior: $cit, location-hierarchy_subordinate: $ar) isa location-hierarchy;
       """
 
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match $lh (location-hierarchy_superior: $continent, location-hierarchy_subordinate: $area) isa location-hierarchy;
       $continent isa continent; $area isa area;
       get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: queried relation is a supertype of the inferred relation
@@ -255,13 +255,13 @@ Feature: Resolution Test Framework
       $b isa man;
       """
 
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match ($w, $m) isa family-relation; $w isa woman; get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then materialised and reasoned databases are the same size
 
 
   @ignore
@@ -296,7 +296,7 @@ Feature: Resolution Test Framework
       $c2 has name $n2; $n2 "another-company";
       """
 
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match $com isa company;
@@ -304,8 +304,8 @@ Feature: Resolution Test Framework
       not {$com has is-liable $liability;};
       get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: a rule containing a negation
@@ -342,13 +342,13 @@ Feature: Resolution Test Framework
       $c2 has name $n2; $n2 "another-company";
       """
 
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match $com isa company, has is-liable $lia; $lia true; get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: querying with multiple negations
@@ -383,10 +383,10 @@ Feature: Resolution Test Framework
       $c2 has name $n2; $n2 "another-company";
       """
 
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match $com isa company; not { $com has is-liable $lia; $lia true; }; not { $com has name $n; $n "the-company"; }; get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then materialised and reasoned databases are the same size

--- a/behaviour/graql/reasoner/roleplayer-attachment.feature
+++ b/behaviour/graql/reasoner/roleplayer-attachment.feature
@@ -17,15 +17,15 @@
 
 Feature: Roleplayer Attachment Resolution
 
-  Background: Set up keyspaces for resolution testing
+  Background: Set up databases for resolution testing
 
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection open sessions for keyspaces:
+    Given connection delete all databases
+    Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised keyspace is named: materialised
-    Given reasoned keyspace is named: reasoned
+    Given materialised database is named: materialised
+    Given reasoned database is named: reasoned
     Given for each session, graql define
       """
       define
@@ -85,16 +85,16 @@ Feature: Roleplayer Attachment Resolution
       (ruled-person: $x) isa dominion;
       (ruled-person: $y) isa dominion;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
         (ruled-person: $x, ruler: $y) isa dominion;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 2
-    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 2
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when fixed (#75)
@@ -124,16 +124,16 @@ Feature: Roleplayer Attachment Resolution
       (ruled-person: $x) isa dominion;
       (ruled-person: $y) isa dominion;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
         (ruled-person: $x, ruler: $y);
       get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 2
-    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 2
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when fixed (#75)
@@ -159,22 +159,22 @@ Feature: Roleplayer Attachment Resolution
 
       (navigator: $y, chef: $x) isa ship-crew;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
         (captain: $x, navigator: $y) isa ship-crew;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
     Then answer set is equivalent for graql query
       """
       match
         (captain: $x, navigator: $y, chef: $x) isa ship-crew;
       get;
       """
-    Then materialised and reasoned keyspaces are the same size
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when fixed (#75)
@@ -200,15 +200,15 @@ Feature: Roleplayer Attachment Resolution
 
       (navigator: $y, captain: $x) isa ship-crew;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
         (captain: $x, captain: $x) isa ship-crew;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
     Then for graql query
       """
       match
@@ -216,17 +216,17 @@ Feature: Roleplayer Attachment Resolution
       get;
       """
     # too many captains - no match
-    Then answer size in reasoned keyspace is: 0
+    Then answer size in reasoned database is: 0
     Then for graql query
       """
       match
         (captain: $x) isa ship-crew;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # we have more captains than we need, but there is still only 1 matching relation instance
-    Then answer size in reasoned keyspace is: 1
-    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 1
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when fixed (#75)
@@ -252,18 +252,18 @@ Feature: Roleplayer Attachment Resolution
 
       (captain: $x, navigator: $y) isa ship-crew;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
         (navigator: $x, navigator: $y) isa ship-crew;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # x        | y        |
     # Maria    | Isabella |
     # Isabella | Maria    |
-    Then answer size in reasoned keyspace is: 2
+    Then answer size in reasoned database is: 2
     Then answer set is equivalent for graql query
       """
       match
@@ -271,4 +271,4 @@ Feature: Roleplayer Attachment Resolution
         $x != $y;
       get;
       """
-    Then materialised and reasoned keyspaces are the same size
+    Then materialised and reasoned databases are the same size

--- a/behaviour/graql/reasoner/schema-queries.feature
+++ b/behaviour/graql/reasoner/schema-queries.feature
@@ -17,15 +17,15 @@
 
 Feature: Schema Query Resolution (Variable Types)
 
-  Background: Set up keyspaces for resolution testing
+  Background: Set up databases for resolution testing
 
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection open sessions for keyspaces:
+    Given connection delete all databases
+    Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised keyspace is named: materialised
-    Given reasoned keyspace is named: reasoned
+    Given materialised database is named: materialised
+    Given reasoned database is named: reasoned
     Given for each session, graql define
       """
       define
@@ -87,34 +87,34 @@ Feature: Schema Query Resolution (Variable Types)
       $y isa person;
       $z isa person;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Given for graql query
       """
       match $x isa entity; get;
       """
-    Given answer size in reasoned keyspace is: 3
+    Given answer size in reasoned database is: 3
     Given for graql query
       """
       match $x isa relation; get;
       """
     # (xx, yy, zz, xy, xz, yz)
-    Given answer size in reasoned keyspace is: 6
+    Given answer size in reasoned database is: 6
     Given for graql query
       """
       match $x isa attribute; get;
       """
-    Given answer size in reasoned keyspace is: 1
+    Given answer size in reasoned database is: 1
     Then for graql query
       """
       match $x isa $type; get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # 3 people x 3 types of person {person,entity,thing}
     # 6 friendships x 3 types of friendship {friendship, relation, thing}
     # 1 name x 3 types of name {name,attribute,thing}
     # = 9 + 18 + 3 = 30
-    Then answer size in reasoned keyspace is: 30
-    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 30
+    Then materialised and reasoned databases are the same size
 
 
   @ignore
@@ -140,21 +140,21 @@ Feature: Schema Query Resolution (Variable Types)
       $y isa person, has name "Richard";
       $z isa person, has name "Rupert";
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Given for graql query
       """
       match ($u, $v) isa relation; get;
       """
     # (xx, yy, zz, xy, xz, yz, yx, zx, zy)
-    Given answer size in reasoned keyspace is: 9
+    Given answer size in reasoned database is: 9
     Then for graql query
       """
       match ($u, $v) isa $type; get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # 3 possible $u x 3 possible $v x 3 possible $type {friendship,relation,thing}
-    Then answer size in reasoned keyspace is: 27
-    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 27
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps once schema queries are resolvable (#75)
@@ -202,15 +202,15 @@ Feature: Schema Query Resolution (Variable Types)
       $x isa person, has name "Sharon";
       $y isa person, has name "Tobias";
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Given for graql query
       """
       match
         $x isa relation;
       get;
       """
-    Given all answers are correct in reasoned keyspace
-    Given answer size in reasoned keyspace is: 6
+    Given all answers are correct in reasoned database
+    Given answer size in reasoned database is: 6
     Then for graql query
       """
       match
@@ -218,11 +218,11 @@ Feature: Schema Query Resolution (Variable Types)
         $type has contract;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # friendship can't have a contract... at least, not in this pristine test world
     # note: enforcing 'has contract' also eliminates 'relation' and 'thing' as possible types
-    Then answer size in reasoned keyspace is: 4
-    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 4
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps once schema queries are resolvable (#75)
@@ -252,13 +252,13 @@ Feature: Schema Query Resolution (Variable Types)
       $y isa person, has name "Richard";
       $z isa person, has name "Rupert";
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Given for graql query
       """
       match $x isa relation; get;
       """
     # 3 friendships, 3 employments
-    Given answer size in reasoned keyspace is: 6
+    Given answer size in reasoned database is: 6
     Then for graql query
       """
       match
@@ -266,10 +266,10 @@ Feature: Schema Query Resolution (Variable Types)
         $type sub relation;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # 3 friendships, 3 employments, 6 relations
-    Then answer size in reasoned keyspace is: 12
-    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 12
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps once schema queries are resolvable (#75)
@@ -317,15 +317,15 @@ Feature: Schema Query Resolution (Variable Types)
       $x isa person, has name "Sharon";
       $y isa person, has name "Tobias";
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Given for graql query
       """
       match
         $x isa relation;
       get;
       """
-    Given all answers are correct in reasoned keyspace
-    Given answer size in reasoned keyspace is: 6
+    Given all answers are correct in reasoned database
+    Given answer size in reasoned database is: 6
     Then for graql query
       """
       match
@@ -333,11 +333,11 @@ Feature: Schema Query Resolution (Variable Types)
         $type plays documented-thing;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # friendship can't be a documented-thing
     # note: enforcing 'plays documented-thing' also eliminates 'relation' and 'thing' as possible types
-    Then answer size in reasoned keyspace is: 4
-    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 4
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: implement this once roles are scoped to relations
@@ -370,15 +370,15 @@ Feature: Schema Query Resolution (Variable Types)
       $z isa colonel;
       $w isa colonel;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Given for graql query
       """
       match
         (employee: $x, employer: $y) isa employment;
       get;
       """
-    Given all answers are correct in reasoned keyspace
-    Given answer size in reasoned keyspace is: 3
+    Given all answers are correct in reasoned database
+    Given answer size in reasoned database is: 3
     Then for graql query
       """
       match
@@ -386,9 +386,9 @@ Feature: Schema Query Resolution (Variable Types)
         $x isa $type;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # 3 colonels * 5 supertypes of colonel (colonel, military-person, person, entity, thing)
-    Then answer size in reasoned keyspace is: 15
+    Then answer size in reasoned database is: 15
     Then for graql query
       """
       match
@@ -396,11 +396,11 @@ Feature: Schema Query Resolution (Variable Types)
         $x isa $type;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # (3 colonels * 5 supertypes of colonel * 1 company)
     # + (1 company * 3 supertypes of company * 3 colonels)
-    Then answer size in reasoned keyspace is: 24
-    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 24
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps once schema queries are resolvable (#75)
@@ -447,7 +447,7 @@ Feature: Schema Query Resolution (Variable Types)
       (employee: $s3, employer: $c2) isa employment;
       (employee: $s4, employer: $c2prime) isa employment;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
@@ -460,10 +460,10 @@ Feature: Schema Query Resolution (Variable Types)
         $y != $x;
       get $x, $y;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # All companies match when $type is company (or entity)
     # Query returns {ab,ac,ad,bc,bd,cd} and each of them with the variables flipped
-    Then answer size in reasoned keyspace is: 12
+    Then answer size in reasoned database is: 12
     Then for graql query
       """
       match
@@ -482,8 +482,8 @@ Feature: Schema Query Resolution (Variable Types)
     # $type is forced to be either finance-company or retail-company, restricting the answer space
     # Query returns {ab,cd} and each of them with the variables flipped
     # Note: the two Captain Obvious rules should not affect the answer, as the concepts retain their original types
-    Then answer size in reasoned keyspace is: 4
-    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 4
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when type generation is supported in resolution test framework (#75)
@@ -514,7 +514,7 @@ Feature: Schema Query Resolution (Variable Types)
       insert
       $x isa person, has name "Romeo";
       """
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Given for graql query
       """
       match
@@ -522,9 +522,9 @@ Feature: Schema Query Resolution (Variable Types)
         $type sub entity;
       get $x, $type;
       """
-#    Given all answers are correct in reasoned keyspace
+#    Given all answers are correct in reasoned database
     # entity, person, duelist, poet
-    Given answer size in reasoned keyspace is: 4
+    Given answer size in reasoned database is: 4
     Then for graql query
       """
       match
@@ -534,10 +534,10 @@ Feature: Schema Query Resolution (Variable Types)
         $type2 != $type;
       get $x, $type;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # entity, person, poet
-    Then answer size in reasoned keyspace is: 3
-#    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 3
+#    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when type generation is supported in resolution test framework (#75)
@@ -568,7 +568,7 @@ Feature: Schema Query Resolution (Variable Types)
       insert
       $x isa person, has name "Romeo";
       """
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Given for graql query
       """
       match
@@ -576,9 +576,9 @@ Feature: Schema Query Resolution (Variable Types)
         $type sub entity;
       get $x, $type;
       """
-#    Given all answers are correct in reasoned keyspace
+#    Given all answers are correct in reasoned database
     # entity, person, duelist, poet
-    Given answer size in reasoned keyspace is: 4
+    Given answer size in reasoned database is: 4
     Then for graql query
       """
       match
@@ -588,7 +588,7 @@ Feature: Schema Query Resolution (Variable Types)
         $type2 != $type;
       get $x, $type;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # entity, person, poet
-    Then answer size in reasoned keyspace is: 3
-#    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 3
+#    Then materialised and reasoned databases are the same size

--- a/behaviour/graql/reasoner/test-framework.feature
+++ b/behaviour/graql/reasoner/test-framework.feature
@@ -17,15 +17,15 @@
 
 Feature: Resolution Test Framework
 
-  Background: Set up keyspaces for resolution testing
+  Background: Set up databases for resolution testing
 
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection open sessions for keyspaces:
+    Given connection delete all databases
+    Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised keyspace is named: materialised
-    Given reasoned keyspace is named: reasoned
+    Given materialised database is named: materialised
+    Given reasoned database is named: reasoned
 
 
   Scenario: basic rule
@@ -50,13 +50,13 @@ Feature: Resolution Test Framework
       insert
       $x isa company;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match $co has name $n; get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: compounding rules
@@ -94,13 +94,13 @@ Feature: Resolution Test Framework
       $co isa company;
       """
 
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match $co has is-liable $l; get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: 2-hop transitivity
@@ -143,7 +143,7 @@ Feature: Resolution Test Framework
       (superior: $cit, subordinate: $ar) isa location-hierarchy;
       """
 
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
@@ -151,8 +151,8 @@ Feature: Resolution Test Framework
       (superior: $l, subordinate: $k) isa location-hierarchy;
       get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then materialised and reasoned databases are the same size
 
 
   @ignore
@@ -202,15 +202,15 @@ Feature: Resolution Test Framework
       (location-hierarchy_superior: $cit, location-hierarchy_subordinate: $ar) isa location-hierarchy;
       """
 
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match $lh (location-hierarchy_superior: $continent, location-hierarchy_subordinate: $area) isa location-hierarchy;
       $continent isa continent; $area isa area;
       get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: queried relation is a supertype of the inferred relation
@@ -255,13 +255,13 @@ Feature: Resolution Test Framework
       $b isa man;
       """
 
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match ($w, $m) isa family-relation; $w isa woman; get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then materialised and reasoned databases are the same size
 
 
   @ignore
@@ -296,7 +296,7 @@ Feature: Resolution Test Framework
       $c2 has name $n2; $n2 "another-company";
       """
 
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match $com isa company;
@@ -304,8 +304,8 @@ Feature: Resolution Test Framework
       not {$com has is-liable $liability;};
       get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: a rule containing a negation
@@ -342,13 +342,13 @@ Feature: Resolution Test Framework
       $c2 has name $n2; $n2 "another-company";
       """
 
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match $com isa company, has is-liable $lia; $lia true; get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: querying with multiple negations
@@ -383,10 +383,10 @@ Feature: Resolution Test Framework
       $c2 has name $n2; $n2 "another-company";
       """
 
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match $com isa company; not { $com has is-liable $lia; $lia true; }; not { $com has name $n; $n "the-company"; }; get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then materialised and reasoned databases are the same size

--- a/behaviour/graql/reasoner/type-generation.feature
+++ b/behaviour/graql/reasoner/type-generation.feature
@@ -17,15 +17,15 @@
 
 Feature: Type Generation Resolution
 
-  Background: Set up keyspaces for resolution testing
+  Background: Set up databases for resolution testing
 
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection open sessions for keyspaces:
+    Given connection delete all databases
+    Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised keyspace is named: materialised
-    Given reasoned keyspace is named: reasoned
+    Given materialised database is named: materialised
+    Given reasoned database is named: reasoned
 
 
   # TODO: re-enable all steps once attribute re-attachment is resolvable
@@ -48,20 +48,20 @@ Feature: Type Generation Resolution
       insert
       $x isa baseEntity;
       """
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Then for graql query
       """
       match $x isa derivedEntity; get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
     Then for graql query
       """
       match $x isa $type; get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 4
-#    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 4
+#    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps once attribute re-attachment is resolvable
@@ -100,26 +100,26 @@ Feature: Type Generation Resolution
       $y isa subEntity;    # -> derivedEntity, directDerivedEntity
       $z isa subSubEntity; # -> derivedEntity
       """
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Then for graql query
       """
       match $x isa derivedEntity; get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 2
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 2
     Then for graql query
       """
       match $x isa! derivedEntity; get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 2
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 2
     Then for graql query
       """
       match $x isa directDerivedEntity; get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
-#    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
+#    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps once attribute re-attachment is resolvable
@@ -157,22 +157,22 @@ Feature: Type Generation Resolution
       (role1:$x, role2:$y) isa baseRelation;
       (role1:$y, role2:$x) isa baseRelation;
       """
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Then for graql query
       """
       match $x isa baseEntity; get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 2
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 2
     Then for graql query
       """
       match
         $x isa derivedEntity;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 2
-#    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 2
+#    Then materialised and reasoned databases are the same size
 
 
   @ignore
@@ -203,19 +203,19 @@ Feature: Type Generation Resolution
       insert
       $x isa baseEntity, has baseAttribute "derived";
       """
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Then for graql query
       """
       match $x isa baseEntity; get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
     Then for graql query
       """
       match $x isa baseAttribute; get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
     Then for graql query
       """
       match
@@ -223,9 +223,9 @@ Feature: Type Generation Resolution
         $x isa baseEntity;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
-#    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
+#    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps once attribute re-attachment is resolvable
@@ -277,23 +277,23 @@ Feature: Type Generation Resolution
       (baseRole: $y) isa subRelation;
       (baseRole: $z) isa subSubRelation;
       """
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Then for graql query
       """
       match ($x) isa derivedRelation; get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 2
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 2
     Then for graql query
       """
       match ($x) isa! derivedRelation; get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 2
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 2
     Then for graql query
       """
       match ($x) isa directDerivedRelation; get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
-#    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
+#    Then materialised and reasoned databases are the same size

--- a/behaviour/graql/reasoner/type-hierarchy.feature
+++ b/behaviour/graql/reasoner/type-hierarchy.feature
@@ -17,15 +17,15 @@
 
 Feature: Type Hierarchy Resolution
 
-  Background: Set up keyspaces for resolution testing
+  Background: Set up databases for resolution testing
 
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection open sessions for keyspaces:
+    Given connection delete all databases
+    Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised keyspace is named: materialised
-    Given reasoned keyspace is named: reasoned
+    Given materialised database is named: materialised
+    Given reasoned database is named: reasoned
 
 
   Scenario: subtypes trigger rules based on their parents; parent types don't trigger rules based on their children
@@ -76,7 +76,7 @@ Feature: Type Hierarchy Resolution
       (performer:$x, writer:$v) isa performance;  # child - child    -> satisfies rule
       (performer:$y, writer:$v) isa performance;  # person - child   -> doesn't satisfy rule
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
@@ -85,9 +85,9 @@ Feature: Type Hierarchy Resolution
         (actor: $x, film-writer: $y) isa film-production;
       get;
       """
-    Then all answers are correct in reasoned keyspace
+    Then all answers are correct in reasoned database
     # Answers are (actor:$x, film-writer:$z) and (actor:$x, film-writer:$v)
-    Then answer size in reasoned keyspace is: 2
+    Then answer size in reasoned database is: 2
     Then for graql query
       """
       match
@@ -97,8 +97,8 @@ Feature: Type Hierarchy Resolution
         $y has name 'a';
       get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 2
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 2
     Then for graql query
       """
       match
@@ -107,9 +107,9 @@ Feature: Type Hierarchy Resolution
         (actor: $x, film-writer: $y) isa film-production;
       get;
       """
-    Then all answers are correct in reasoned keyspace
+    Then all answers are correct in reasoned database
     # Answer is (actor:$x, film-writer:$v) ONLY
-    Then answer size in reasoned keyspace is: 1
+    Then answer size in reasoned database is: 1
     Then for graql query
       """
       match
@@ -119,8 +119,8 @@ Feature: Type Hierarchy Resolution
         $y has name 'a';
       get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
     Then for graql query
       """
       match
@@ -129,9 +129,9 @@ Feature: Type Hierarchy Resolution
         (actor: $x, film-writer: $y) isa film-production;
       get;
       """
-    Then all answers are correct in reasoned keyspace
+    Then all answers are correct in reasoned database
     # Answers are (actor:$x, film-writer:$z) and (actor:$x, film-writer:$v)
-    Then answer size in reasoned keyspace is: 2
+    Then answer size in reasoned database is: 2
     Then for graql query
       """
       match
@@ -141,9 +141,9 @@ Feature: Type Hierarchy Resolution
         $y has name 'a';
       get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 2
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 2
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: when matching different roles to those that are actually inferred, no answers are returned
@@ -181,20 +181,20 @@ Feature: Type Hierarchy Resolution
       $y isa person;
       (child: $x, parent: $y) isa family;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     # Matching a sibling of the actual role
     Then for graql query
       """
       match (child: $x, father: $y) isa large-family; get;
       """
-    Then answer size in reasoned keyspace is: 0
+    Then answer size in reasoned database is: 0
     # Matching two siblings when only one is present
     Then for graql query
       """
       match (mother: $x, father: $y) isa large-family; get;
       """
-    Then answer size in reasoned keyspace is: 0
-    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 0
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: when a sub-relation is inferred, it can be retrieved by matching its super-relation and sub-roles
@@ -237,15 +237,15 @@ Feature: Type Hierarchy Resolution
       $y isa person;
       (writer:$x, performer:$y) isa performance;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     # sub-roles, super-relation
     Then for graql query
       """
       match (scifi-writer:$x, scifi-actor:$y) isa film-production; get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: when a sub-relation is inferred, it can be retrieved by matching its sub-relation and super-roles
@@ -288,15 +288,15 @@ Feature: Type Hierarchy Resolution
       $y isa person;
       (writer:$x, performer:$y) isa performance;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     # super-roles, sub-relation
     Then for graql query
       """
       match (film-writer:$x, actor:$y) isa scifi-production; get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: when a sub-relation is inferred, it can be retrieved by matching its super-relation and super-roles
@@ -339,15 +339,15 @@ Feature: Type Hierarchy Resolution
       $y isa person;
       (writer:$x, performer:$y) isa performance;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     # super-roles, super-relation
     Then for graql query
       """
       match (film-writer:$x, actor:$y) isa film-production; get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: when a rule is recursive, its inferences respect type hierarchies
@@ -408,7 +408,7 @@ Feature: Type Hierarchy Resolution
       (performer:$x, writer:$v) isa performance;  # child - child    -> satisfies rule
       (performer:$y, writer:$v) isa performance;  # person - child   -> doesn't satisfy rule
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
@@ -417,9 +417,9 @@ Feature: Type Hierarchy Resolution
         (actor: $x, film-writer: $y) isa film-production;
       get;
       """
-    Then all answers are correct in reasoned keyspace
+    Then all answers are correct in reasoned database
     # Answers are (actor:$x, film-writer:$z) and (actor:$x, film-writer:$v)
-    Then answer size in reasoned keyspace is: 2
+    Then answer size in reasoned database is: 2
     Then for graql query
       """
       match
@@ -429,8 +429,8 @@ Feature: Type Hierarchy Resolution
         $y has name 'a';
       get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 2
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 2
     Then for graql query
       """
       match
@@ -439,9 +439,9 @@ Feature: Type Hierarchy Resolution
         (actor: $x, film-writer: $y) isa film-production;
       get;
       """
-    Then all answers are correct in reasoned keyspace
+    Then all answers are correct in reasoned database
     # Answer is (actor:$x, film-writer:$v) ONLY
-    Then answer size in reasoned keyspace is: 1
+    Then answer size in reasoned database is: 1
     Then for graql query
       """
       match
@@ -451,8 +451,8 @@ Feature: Type Hierarchy Resolution
         $y has name 'a';
       get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
     Then for graql query
       """
       match
@@ -461,9 +461,9 @@ Feature: Type Hierarchy Resolution
         (actor: $x, film-writer: $y) isa film-production;
       get;
       """
-    Then all answers are correct in reasoned keyspace
+    Then all answers are correct in reasoned database
     # Answers are (actor:$x, film-writer:$z) and (actor:$x, film-writer:$v)
-    Then answer size in reasoned keyspace is: 2
+    Then answer size in reasoned database is: 2
     Then for graql query
       """
       match
@@ -473,9 +473,9 @@ Feature: Type Hierarchy Resolution
         $y has name 'a';
       get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 2
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 2
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: querying for a super-relation gives the same answer as querying for its inferred sub-relation
@@ -518,15 +518,15 @@ Feature: Type Hierarchy Resolution
       $y isa person;
       (parent:$x, child:$y) isa family;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
         (home-owner: $x, resident: $y) isa residence;
       get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
     Then for graql query
       """
       match
@@ -534,9 +534,9 @@ Feature: Type Hierarchy Resolution
         (parent-home-owner: $x, child-resident: $y) isa family-residence;
       get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps once attribute re-attachment is resolvable
@@ -562,15 +562,15 @@ Feature: Type Hierarchy Resolution
       insert
       $x isa panda;
       """
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Then for graql query
       """
       match
         $x isa person;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
     Then for graql query
       """
       match
@@ -578,6 +578,6 @@ Feature: Type Hierarchy Resolution
         $x isa drunk-person;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
-#    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
+#    Then materialised and reasoned databases are the same size

--- a/behaviour/graql/reasoner/value-predicate.feature
+++ b/behaviour/graql/reasoner/value-predicate.feature
@@ -17,15 +17,15 @@
 
 Feature: Value Predicate Resolution
 
-  Background: Set up keyspaces for resolution testing
+  Background: Set up databases for resolution testing
 
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection open sessions for keyspaces:
+    Given connection delete all databases
+    Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised keyspace is named: materialised
-    Given reasoned keyspace is named: reasoned
+    Given materialised database is named: materialised
+    Given reasoned database is named: reasoned
     Given for each session, graql define
       """
       define
@@ -83,17 +83,17 @@ Feature: Value Predicate Resolution
       insert
       $se isa tortoise, has age 1;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match $x has is-old $r; get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
+    Then materialised and reasoned databases are the same size
 
 
-  # TODO: re-enable all steps once materialised keyspace counts duplicate attributes only once
+  # TODO: re-enable all steps once materialised database counts duplicate attributes only once
   Scenario Outline: when querying for inferred attributes with `<op>`, the answers matching the predicate are returned
     Given for each session, graql define
       """
@@ -110,7 +110,7 @@ Feature: Value Predicate Resolution
       $x isa person;
       $y isa person;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
@@ -118,9 +118,9 @@ Feature: Value Predicate Resolution
         $n <op> 1667;
       get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: <answer-size>
-#    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: <answer-size>
+#    Then materialised and reasoned databases are the same size
 
     Examples:
       | op  | answer-size |
@@ -148,7 +148,7 @@ Feature: Value Predicate Resolution
       $x isa person, has name "Alice";
       $y isa person, has name "Bob";
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
@@ -157,9 +157,9 @@ Feature: Value Predicate Resolution
         $m <op> $n;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: <answer-size>
-#    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: <answer-size>
+#    Then materialised and reasoned databases are the same size
 
     Examples:
       | op  | answer-size |
@@ -188,7 +188,7 @@ Feature: Value Predicate Resolution
       $x isa person, has name "Alice";
       $y isa person, has name "Bob";
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
@@ -198,9 +198,9 @@ Feature: Value Predicate Resolution
         $n <op> 1667;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: <answer-size>
-#    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: <answer-size>
+#    Then materialised and reasoned databases are the same size
 
     Examples:
       | op  | answer-size |
@@ -241,7 +241,7 @@ Feature: Value Predicate Resolution
       $y isa soft-drink, has name "Tango";
       $r "Ocado" isa retailer;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
@@ -250,12 +250,12 @@ Feature: Value Predicate Resolution
         $unwanted == "Ocado";
       get;
       """
-    Given all answers are correct in reasoned keyspace
+    Given all answers are correct in reasoned database
     # x     | r     |
     # Fanta | Tesco |
     # Tango | Tesco |
-    Then answer size in reasoned keyspace is: 2
-    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 2
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: inferred attributes can be matched by equality to a variable that is not equal to a specified value
@@ -287,7 +287,7 @@ Feature: Value Predicate Resolution
       $y isa soft-drink, has name "Tango";
       $r "Ocado" isa retailer;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
@@ -296,12 +296,12 @@ Feature: Value Predicate Resolution
         $r == $wanted;
       get;
       """
-    Given all answers are correct in reasoned keyspace
+    Given all answers are correct in reasoned database
     # x     | r     |
     # Fanta | Ocado |
     # Tango | Ocado |
-    Then answer size in reasoned keyspace is: 2
-    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 2
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when fixed (#75)
@@ -338,7 +338,7 @@ Feature: Value Predicate Resolution
       """
       insert $x isa soft-drink, has name "Fanta";
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
@@ -346,9 +346,9 @@ Feature: Value Predicate Resolution
         $rx contains "land";
       get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 2
-#    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 2
+#    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when fixed (#75)
@@ -387,7 +387,7 @@ Feature: Value Predicate Resolution
       $x isa soft-drink, has name "Fanta";
       $y isa soft-drink, has name "Tango";
       """
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Then for graql query
       """
       match
@@ -397,7 +397,7 @@ Feature: Value Predicate Resolution
         $ry contains 'land';
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # x     | rx        | y     | ry        |
     # Fanta | Iceland   | Tango | Iceland   |
     # Tango | Iceland   | Fanta | Iceland   |
@@ -407,8 +407,8 @@ Feature: Value Predicate Resolution
     # Fanta | Poundland | Fanta | Poundland |
     # Tango | Iceland   | Tango | Iceland   |
     # Tango | Poundland | Tango | Poundland |
-    Then answer size in reasoned keyspace is: 8
-#    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 8
+#    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when fixed (#75)
@@ -447,7 +447,7 @@ Feature: Value Predicate Resolution
       $x isa soft-drink, has name "Fanta";
       $y isa soft-drink, has name "Tango";
       """
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Then for graql query
       """
       match
@@ -457,7 +457,7 @@ Feature: Value Predicate Resolution
         $ry contains 'land';
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # x     | rx        | y     | ry        |
     # Fanta | Iceland   | Tango | Poundland |
     # Tango | Iceland   | Fanta | Poundland |
@@ -475,8 +475,8 @@ Feature: Value Predicate Resolution
     # Tango | Londis    | Tango | Poundland |
     # Fanta | Londis    | Fanta | Iceland   |
     # Tango | Londis    | Tango | Iceland   |
-    Then answer size in reasoned keyspace is: 16
-#    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 16
+#    Then materialised and reasoned databases are the same size
 
 
   Scenario: in a rule, `not { $x == $y; }` is the same as saying `$x !== $y`
@@ -508,7 +508,7 @@ Feature: Value Predicate Resolution
       $y isa soft-drink, has name "Tango";
       $r "Ocado" isa retailer;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Given for graql query
       """
       match
@@ -516,11 +516,11 @@ Feature: Value Predicate Resolution
         $r !== "Ocado";
       get;
       """
-    Given all answers are correct in reasoned keyspace
+    Given all answers are correct in reasoned database
     # x     | r     |
     # Fanta | Tesco |
     # Tango | Tesco |
-    Given answer size in reasoned keyspace is: 2
+    Given answer size in reasoned database is: 2
     Then for graql query
       """
       match
@@ -528,9 +528,9 @@ Feature: Value Predicate Resolution
         not { $r == "Ocado"; };
       get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 2
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 2
+    Then materialised and reasoned databases are the same size
 
 
   Scenario: in a rule, `not { $x !== $y; }` is the same as saying `$x == $y`
@@ -562,7 +562,7 @@ Feature: Value Predicate Resolution
       $y isa soft-drink, has name "Tango";
       $r "Ocado" isa retailer;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Given for graql query
       """
       match
@@ -570,11 +570,11 @@ Feature: Value Predicate Resolution
         $r == "Ocado";
       get;
       """
-    Given all answers are correct in reasoned keyspace
+    Given all answers are correct in reasoned database
     # x     | r     |
     # Fanta | Ocado |
     # Tango | Ocado |
-    Given answer size in reasoned keyspace is: 2
+    Given answer size in reasoned database is: 2
     Then for graql query
       """
       match
@@ -582,9 +582,9 @@ Feature: Value Predicate Resolution
         not { $r !== "Ocado"; };
       get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 2
-    Then materialised and reasoned keyspaces are the same size
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 2
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: move to negation.feature
@@ -617,7 +617,7 @@ Feature: Value Predicate Resolution
       $y isa soft-drink, has name "Tango";
       $r "Ocado" isa retailer;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
@@ -628,12 +628,12 @@ Feature: Value Predicate Resolution
         };
       get;
       """
-    Then all answers are correct in reasoned keyspace
+    Then all answers are correct in reasoned database
     # x     | r     |
     # Fanta | Tesco |
     # Tango | Tesco |
-    Then answer size in reasoned keyspace is: 2
-    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 2
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps once attribute re-attachment is resolvable
@@ -665,7 +665,7 @@ Feature: Value Predicate Resolution
       $y isa person, has name "Bob", has string-attribute "Safeway";
       $z isa soft-drink, has name "Tango";
       """
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Then for graql query
       """
       match
@@ -674,13 +674,13 @@ Feature: Value Predicate Resolution
         $re !== $sa;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # The string-attributes are transferred to each other, so in fact both people have both Tesco and Safeway
     # x     | re    | y     | sa      |
     # Tango | Tesco | Alice | Safeway |
     # Tango | Tesco | Bob   | Safeway |
-    Then answer size in reasoned keyspace is: 2
-#    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 2
+#    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps once attribute re-attachment is resolvable
@@ -713,7 +713,7 @@ Feature: Value Predicate Resolution
       $y isa person, has name "Bob", has string-attribute "Safeway";
       $z isa soft-drink, has name "Tango";
       """
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Then for graql query
       """
       match
@@ -722,13 +722,13 @@ Feature: Value Predicate Resolution
         not { $re == $sa; };
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # The string-attributes are transferred to each other, so in fact both people have both Tesco and Safeway
     # x     | re    | y     | sa      |
     # Tango | Tesco | Alice | Safeway |
     # Tango | Tesco | Bob   | Safeway |
-    Then answer size in reasoned keyspace is: 2
-#    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 2
+#    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps once implicit attribute variables are resolvable
@@ -756,7 +756,7 @@ Feature: Value Predicate Resolution
       $x isa person, has string-attribute "Tesco";
       $y isa soft-drink, has name "Tesco";
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
@@ -765,7 +765,7 @@ Feature: Value Predicate Resolution
         $ax != $ay;
       get;
       """
-    Then all answers are correct in reasoned keyspace
+    Then all answers are correct in reasoned database
     # x   | ax  | y   | ay  |
     # PER | STA | SOF | NAM |
     # PER | STA | SOF | RET |
@@ -773,8 +773,8 @@ Feature: Value Predicate Resolution
     # SOF | RET | PER | STA |
     # SOF | NAM | SOF | RET |
     # SOF | RET | SOF | NAM |
-    Then answer size in reasoned keyspace is: 6
-    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 6
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when fixed (#75)
@@ -840,7 +840,7 @@ Feature: Value Predicate Resolution
       $p3 "low price" isa price-range;
       $p4 "cheap" isa price-range;
       """
-    When materialised keyspace is completed
+    When materialised database is completed
     Then for graql query
       """
       match
@@ -848,8 +848,8 @@ Feature: Value Predicate Resolution
         ($x, priced-item: $y) isa price-classification;
       get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 2
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 2
     Then for graql query
       """
       match
@@ -857,8 +857,8 @@ Feature: Value Predicate Resolution
         ($x, priced-item: $y) isa price-classification;
       get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
     Then for graql query
       """
       match
@@ -866,8 +866,8 @@ Feature: Value Predicate Resolution
         ($x, priced-item: $y) isa price-classification;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
     Then for graql query
       """
       match
@@ -875,8 +875,8 @@ Feature: Value Predicate Resolution
         ($x, priced-item: $y) isa price-classification;
       get;
       """
-    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 1
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 1
     Then for graql query
       """
       match
@@ -884,10 +884,10 @@ Feature: Value Predicate Resolution
         ($x, priced-item: $y) isa price-classification;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # sum of all previous answers
-    Then answer size in reasoned keyspace is: 5
-    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 5
+    Then materialised and reasoned databases are the same size
 
 
   # TODO: re-enable all steps when resolvable (currently it takes too long to resolve) (#75)
@@ -942,12 +942,12 @@ Feature: Value Predicate Resolution
       (original:$x, reply:$x4) isa reply-of;
       (original:$x, reply:$x5) isa reply-of;
       """
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Then for graql query
       """
       match (predecessor:$x1, successor:$x2) isa message-succession; get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # the (n-1)th triangle number, where n is the number of replies to the first post
-    Then answer size in reasoned keyspace is: 10
-#    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 10
+#    Then materialised and reasoned databases are the same size

--- a/behaviour/graql/reasoner/variable-roles.feature
+++ b/behaviour/graql/reasoner/variable-roles.feature
@@ -18,15 +18,15 @@
 # TODO: re-enable all steps in file when Grakn is faster
 Feature: Variable Role Resolution
 
-  Background: Set up keyspaces for resolution testing
+  Background: Set up databases for resolution testing
 
     Given connection has been opened
-    Given connection delete all keyspaces
-    Given connection open sessions for keyspaces:
+    Given connection delete all databases
+    Given connection open sessions for databases:
       | materialised |
       | reasoned     |
-    Given materialised keyspace is named: materialised
-    Given reasoned keyspace is named: reasoned
+    Given materialised database is named: materialised
+    Given reasoned database is named: reasoned
     Given for each session, graql define
       """
       define
@@ -162,15 +162,15 @@ Feature: Variable Role Resolution
 
 
   Scenario: when querying a binary relation, introducing a variable role doubles the answer size
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Given for graql query
       """
       match
         (role1: $a, role2: $b) isa binary-base;
       get;
       """
-#    Given all answers are correct in reasoned keyspace
-    Given answer size in reasoned keyspace is: 9
+#    Given all answers are correct in reasoned database
+    Given answer size in reasoned database is: 9
     Then for graql query
       """
       match
@@ -178,21 +178,21 @@ Feature: Variable Role Resolution
       get;
       """
     # $r1 in {role, role2} (2 options => double answer size)
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 18
-#    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 18
+#    Then materialised and reasoned databases are the same size
 
 
   Scenario: converting a fixed role to a variable role bound with `type` does not modify the answer size
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Given for graql query
       """
       match
         (role1: $a, $r1: $b) isa binary-base;
       get;
       """
-#    Given all answers are correct in reasoned keyspace
-    Given answer size in reasoned keyspace is: 18
+#    Given all answers are correct in reasoned database
+    Given answer size in reasoned database is: 18
     # This query should be equivalent to the one above
     Then for graql query
       """
@@ -201,21 +201,21 @@ Feature: Variable Role Resolution
         $r1 type role1;
       get $a, $b, $r2;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 18
-#    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 18
+#    Then materialised and reasoned databases are the same size
 
 
   Scenario: when querying a binary relation, introducing a meta 'role' and a variable role triples the answer size
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Given for graql query
       """
       match
         (role1: $a, role2: $b) isa binary-base;
       get;
       """
-#    Given all answers are correct in reasoned keyspace
-    Given answer size in reasoned keyspace is: 9
+#    Given all answers are correct in reasoned database
+    Given answer size in reasoned database is: 9
     Then for graql query
       """
       match
@@ -223,23 +223,23 @@ Feature: Variable Role Resolution
       get;
       """
     # $r1 in {role, role1, role2} (3 options => triple answer size)
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 27
-#    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 27
+#    Then materialised and reasoned databases are the same size
 
 
   @ignore
   # TODO: need to determine what this should do; currently it returns 12 answers (grakn#5677)
   Scenario: converting a fixed role to a variable bound with 'type role' (?)
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Given for graql query
       """
       match
         (role: $a, $r1: $b) isa binary-base;
       get;
       """
-#    Given all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 27
+#    Given all answers are correct in reasoned database
+    Then answer size in reasoned database is: 27
     # This query should be equivalent to the one above
     Then for graql query
       """
@@ -248,23 +248,23 @@ Feature: Variable Role Resolution
         $r1 type role;
       get $a, $b, $r2;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 27
-#    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 27
+#    Then materialised and reasoned databases are the same size
 
 
   @ignore
   # TODO: need to determine what this should do; currently it errors (grakn#5677)
   Scenario: converting a fixed role to a variable bound with 'sub role' (?)
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Given for graql query
       """
       match
         (role: $a, $r1: $b) isa binary-base;
       get;
       """
-#    Given all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 27
+#    Given all answers are correct in reasoned database
+    Then answer size in reasoned database is: 27
     # This query should be equivalent to the one above
     Then for graql query
       """
@@ -273,15 +273,15 @@ Feature: Variable Role Resolution
         $r1 sub role;
       get $a, $b, $r2;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 27
-#    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 27
+#    Then materialised and reasoned databases are the same size
 
 
   @ignore
   # TODO: re-enable when converting a fixed role to a variable bound with meta 'role' does not modify the answer
   Scenario: when all other role variables are bound, introducing a meta 'role' doesn't affect the answer size
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Then for graql query
       """
       match
@@ -291,8 +291,8 @@ Feature: Variable Role Resolution
       get;
       """
     # $r1 must be 'role' and $r2 must be 'role2'
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 9
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 9
     # This query is equivalent to the one above
     Then for graql query
       """
@@ -301,21 +301,21 @@ Feature: Variable Role Resolution
         $r2 type role2;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 9
-#    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 9
+#    Then materialised and reasoned databases are the same size
 
 
   Scenario: when querying a binary relation, introducing two variable roles multiplies the answer size by 7
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Given for graql query
       """
       match
         (role1: $a, role2: $b) isa binary-base;
       get;
       """
-#    Given all answers are correct in reasoned keyspace
-    Given answer size in reasoned keyspace is: 9
+#    Given all answers are correct in reasoned database
+    Given answer size in reasoned database is: 9
     Then for graql query
       """
       match
@@ -330,9 +330,9 @@ Feature: Variable Role Resolution
     # role1 | role2 |
     # role2 | role  |
     # role2 | role1 |
-#    Then all answers are correct in reasoned keyspace
-    Then answer size in reasoned keyspace is: 63
-#    Then materialised and reasoned keyspaces are the same size
+#    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 63
+#    Then materialised and reasoned databases are the same size
 
 
   # General formula for the answer size with K degrees of freedom [*] on an N-ary relation
@@ -382,7 +382,7 @@ Feature: Variable Role Resolution
   #  }
 
   Scenario: variable roles are correctly mapped to answers for a ternary relation with 3 possible roleplayers
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Then for graql query
       """
       match
@@ -390,25 +390,25 @@ Feature: Variable Role Resolution
         $a1 has name 'a';
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # This query is equivalent to matching ($r2: $a2, $r3: $a3) isa binary-base, as role1 and $a1 each have only 1 value
-    Then answer size in reasoned keyspace is: 63
+    Then answer size in reasoned database is: 63
     Then for graql query
       """
       match
         (ternary-role1: $a1, $r2: $a2, $r3: $a3) isa ternary-base;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # Now the bound role 'role1' is in {a, b, c}, tripling the answer size
-    Then answer size in reasoned keyspace is: 189
+    Then answer size in reasoned database is: 189
     Then for graql query
       """
       match
         ($r1: $a1, $r2: $a2, $r3: $a3) isa ternary-base;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # r1    | r2    | r3    |
     # role  | role  | role  | 1 pattern
     # roleX | role  | role  | 3 patterns: X in {1,2,3}
@@ -423,12 +423,12 @@ Feature: Variable Role Resolution
     # For each pattern, we have one possible match per ternary-base relation
     # and there are 27 ternary-base relations in the knowledge graph (including both material and inferred)
     # giving an answer size of 34 * 27 = 918
-    Then answer size in reasoned keyspace is: 918
-#    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 918
+#    Then materialised and reasoned databases are the same size
 
 
   Scenario: variable roles are correctly mapped to answers for a quaternary relation with 3 possible roleplayers
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Then for graql query
       """
       match
@@ -436,25 +436,25 @@ Feature: Variable Role Resolution
         $a1 has name 'a';
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # This query is equivalent to matching ($r2: $a2, $r3: $a3, $r4: $a4) isa ternary-base
-    Then answer size in reasoned keyspace is: 918
+    Then answer size in reasoned database is: 918
     Then for graql query
       """
       match
         (quat-role1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary-base;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # Now the bound role 'role1' is in {a, b, c}, tripling the answer size
-    Then answer size in reasoned keyspace is: 2754
+    Then answer size in reasoned database is: 2754
     Then for graql query
       """
       match
         ($r1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary-base;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # {r1,r2,r3,r4}
     # 4 occurrences of 'role' | 1 pattern
     # 3 occurrences of 'role' | 16 patterns (4 combinations of 1 role var x (4) distinct roles)
@@ -466,14 +466,14 @@ Feature: Variable Role Resolution
     # For each pattern, we have one possible match per quaternary-base relation
     # and there are 81 quaternary-base relations in the knowledge graph (including both material and inferred)
     # giving an answer size of 209 * 81 = 16929
-    Then answer size in reasoned keyspace is: 16929
-#    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 16929
+#    Then materialised and reasoned databases are the same size
 
 
   # Note: This test uses the sub-relation 'quaternary' while the others use the super-relations '{n}-ary-base'.
   # If this test passes while others fail, there may be an inheritance-related issue.
   Scenario: variable roles are correctly mapped to answers for a quaternary relation with 2 possible roleplayers
-#    When materialised keyspace is completed
+#    When materialised database is completed
     Then for graql query
       """
       match
@@ -481,28 +481,28 @@ Feature: Variable Role Resolution
         $a1 has name 'a';
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # This query is equivalent to matching ($r2: $a2, $r3: $a3, $r4: $a4) isa ternary
-    Then answer size in reasoned keyspace is: 272
+    Then answer size in reasoned database is: 272
     Then for graql query
       """
       match
         (quat-role1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # Now the bound role 'role1' is in {a, b}, doubling the answer size
-    Then answer size in reasoned keyspace is: 544
+    Then answer size in reasoned database is: 544
     Then for graql query
       """
       match
         ($r1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary;
       get;
       """
-#    Then all answers are correct in reasoned keyspace
+#    Then all answers are correct in reasoned database
     # {r1,r2,r3,r4} | 209 patterns (see 'quaternary-base' scenario for details)
     # For each pattern, we have one possible match per quaternary relation
     # and there are 16 quaternary relations in the knowledge graph (including both material and inferred)
     # giving an answer size of 209 * 16 = 3344
-    Then answer size in reasoned keyspace is: 3344
-#    Then materialised and reasoned keyspaces are the same size
+    Then answer size in reasoned database is: 3344
+#    Then materialised and reasoned databases are the same size

--- a/tools/integrity/Validator.java
+++ b/tools/integrity/Validator.java
@@ -355,7 +355,7 @@ public class Validator {
 
      Outline:
 
-     Goal: given a keyspace, verify basic integrity checks are preserved, building up from very low level structures
+     Goal: given a database, verify basic integrity checks are preserved, building up from very low level structures
 
 
      Schema:

--- a/tools/integrity/test/ValidatorIT.java
+++ b/tools/integrity/test/ValidatorIT.java
@@ -42,8 +42,8 @@ public class ValidatorIT {
 
     @Before
     public void openSession() {
-        String randomKeyspace = "ksp_" + (UUID.randomUUID()).toString().replace("-", "_").substring(10);
-        session = client.session(randomKeyspace);
+        String randomDatabase = "ksp_" + (UUID.randomUUID()).toString().replace("-", "_").substring(10);
+        session = client.session(randomDatabase);
         loadSchema(session);
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

Keyspace, as terminology, has been replaced with database, so this change should be reflected in our tests for consistency.

## What are the changes implemented in this PR?

- Renamed keyspace to database