### PR TITLE
In Concept BDDs, don't commit transactions after error steps

### DIFF
--- a/behaviour/concept/thing/entity.feature
+++ b/behaviour/concept/thing/entity.feature
@@ -128,8 +128,9 @@ Feature: Concept Entity
     When $alice = attribute(username) as(string) put: alice
     When $bob = attribute(username) as(string) put: bob
     When entity $a set has: $alice
-    Then entity $a set has: $bob; throws exception
     When transaction commits
+    When session opens transaction of type: write
+    Then entity $a set has: $bob; throws exception
     When session opens transaction of type: write
     When $a = entity(person) get instance with key(username): alice
     When $bob = attribute(username) as(string) get: bob
@@ -139,12 +140,8 @@ Feature: Concept Entity
     When $a = entity(person) create new instance
     When $alice = attribute(username) as(string) put: alice
     When entity $a set has: $alice
-    When $b = entity(person) create new instance
-    Then entity $b set has: $alice; throws exception
-    Then delete entity: $b
     When transaction commits
     When session opens transaction of type: write
-    When $alice = attribute(username) as(string) get: alice
     When $b = entity(person) create new instance
     Then entity $b set has: $alice; throws exception
 

--- a/behaviour/concept/type/entitytype.feature
+++ b/behaviour/concept/type/entitytype.feature
@@ -99,17 +99,20 @@ Feature: Concept Entity Type
     When entity(person) set abstract: true
     When put entity type: company
     Then entity(person) is abstract: true
-    Then entity(person) create new instance; throws exception
-    Then entity(company) is abstract: false
     When transaction commits
     When session opens transaction of type: write
+    Then entity(person) create new instance; throws exception
+    When session opens transaction of type: write
+    Then entity(company) is abstract: false
     Then entity(person) is abstract: true
     Then entity(person) create new instance; throws exception
+    When session opens transaction of type: write
     Then entity(company) is abstract: false
     When entity(company) set abstract: true
     Then entity(company) is abstract: true
-    Then entity(company) create new instance; throws exception
     When transaction commits
+    When session opens transaction of type: write
+    Then entity(company) create new instance; throws exception
     When session opens transaction of type: write
     Then entity(company) is abstract: true
     Then entity(company) create new instance; throws exception
@@ -219,8 +222,9 @@ Feature: Concept Entity Type
 
   Scenario: Entity types cannot subtype itself
     When put entity type: person
-    Then entity(person) set supertype: person; throws exception
     When transaction commits
+    When session opens transaction of type: write
+    Then entity(person) set supertype: person; throws exception
     When session opens transaction of type: write
     Then entity(person) set supertype: person; throws exception
 
@@ -266,7 +270,9 @@ Feature: Concept Entity Type
     When entity(person) set has key type: name
     When entity(person) set has key type: timestamp
     When entity(person) set has key type: timestamp
+    When transaction commits
     Then entity(person) set has key type: is-open; throws exception
+    When session opens transaction of type: write
     Then entity(person) set has key type: rating; throws exception
 
   Scenario: Entity types can have attributes
@@ -705,7 +711,10 @@ Feature: Concept Entity Type
     When entity(person) set has key type: email
     When put entity type: customer
     When entity(customer) set supertype: person
+    When transaction commits
+    When session opens transaction of type: write
     Then entity(customer) set has key type: email; throws exception
+    When session opens transaction of type: write
     Then entity(customer) set has attribute type: email; throws exception
 
   Scenario: Entity types cannot redeclare inherited/overridden key/has attribute types
@@ -727,9 +736,14 @@ Feature: Concept Entity Type
     When entity(customer) set has attribute type: customer-name
     When put entity type: subscriber
     When entity(subscriber) set supertype: customer
+    When transaction commits
+    When session opens transaction of type: write
     Then entity(subscriber) set has key type: email; throws exception
+    When session opens transaction of type: write
     Then entity(subscriber) set has key type: customer-email; throws exception
+    When session opens transaction of type: write
     Then entity(subscriber) set has attribute type: name; throws exception
+    When session opens transaction of type: write
     Then entity(subscriber) set has attribute type: customer-name; throws exception
 
   Scenario: Entity types cannot override declared keys and attributes
@@ -745,7 +759,10 @@ Feature: Concept Entity Type
     When entity(person) set abstract: true
     When entity(person) set has key type: username
     When entity(person) set has attribute type: name
+    When transaction commits
+    When session opens transaction of type: write
     Then entity(person) set has key type: email as username; throws exception
+    When session opens transaction of type: write
     Then entity(person) set has attribute type: first-name as name; throws exception
 
   Scenario: Entity types cannot override inherited keys as attributes
@@ -770,7 +787,9 @@ Feature: Concept Entity Type
     When entity(person) set has attribute type: name
     When put entity type: customer
     When entity(customer) set supertype: person
+    When transaction commits
     Then entity(customer) set has key type: reference as username; throws exception
+    When session opens transaction of type: write
     Then entity(customer) set has attribute type: rating as name; throws exception
 
   Scenario: Entity types can play role types
@@ -1025,7 +1044,10 @@ Feature: Concept Entity Type
     When entity(man) set plays role: fathership:father as parent
     When put entity type: boy
     When entity(boy) set supertype: man
+    When transaction commits
+    When session opens transaction of type: write
     Then entity(boy) set plays role: parentship:parent; throws exception
+    When session opens transaction of type: write
     Then entity(boy) set plays role: fathership:father; throws exception
 
   Scenario: Entity types cannot override declared playing role types


### PR DESCRIPTION
## What is the goal of this PR?

To stop attempting to commit transactions, or perform further concept methods, after a 'throws exception' BDD step. We have decided that this is undesirable behaviour of Grakn - not to mention that it doesn't work in any client (e.g: client-java) - and will be changed in 2.0.

Currently none of our clients are able to commit transactions after an error occurs, but this has in a way occurred "by accident" - Grakn itself does not kill transactions on error, but all of our clients happen to.

## What are the changes implemented in this PR?

Rewrote a large number of BDD scenarios to ensure that transactions are committed before any step that 'throws exception' is executed, and to ensure that a new transaction is opened after every step that 'throws exception'.