### PR TITLE
Type label leading underscore is allowed

### DIFF
--- a/query/language/define.feature
+++ b/query/language/define.feature
@@ -40,6 +40,50 @@ Feature: TypeQL Define Query
       """
     Then transaction commits
 
+  Scenario: type labels can start with an underscore
+    When typeql schema query
+      """
+      define
+      entity _hidden-entity;
+      relation _internal-relation relates _role;
+      attribute _private-name value string;
+      """
+    Then transaction commits
+
+    When connection open schema transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match entity $x;
+      """
+    Then uniquely identify answer concepts
+      | x                     |
+      | label:person          |
+      | label:_hidden-entity  |
+
+    When get answers of typeql read query
+      """
+      match relation $x;
+      """
+    Then uniquely identify answer concepts
+      | x                          |
+      | label:employment           |
+      | label:income               |
+      | label:_internal-relation   |
+
+    When get answers of typeql read query
+      """
+      match attribute $x;
+      """
+    Then uniquely identify answer concepts
+      | x                                |
+      | label:name                       |
+      | label:email                      |
+      | label:start-date                 |
+      | label:employment-reference-code  |
+      | label:phone-nr                   |
+      | label:_private-name              |
+
+
   ################
   # ENTITY TYPES #
   ################

--- a/query/language/define.feature
+++ b/query/language/define.feature
@@ -40,50 +40,6 @@ Feature: TypeQL Define Query
       """
     Then transaction commits
 
-  Scenario: type labels can start with an underscore
-    When typeql schema query
-      """
-      define
-      entity _hidden-entity;
-      relation _internal-relation relates _role;
-      attribute _private-name value string;
-      """
-    Then transaction commits
-
-    When connection open schema transaction for database: typedb
-    When get answers of typeql read query
-      """
-      match entity $x;
-      """
-    Then uniquely identify answer concepts
-      | x                     |
-      | label:person          |
-      | label:_hidden-entity  |
-
-    When get answers of typeql read query
-      """
-      match relation $x;
-      """
-    Then uniquely identify answer concepts
-      | x                          |
-      | label:employment           |
-      | label:income               |
-      | label:_internal-relation   |
-
-    When get answers of typeql read query
-      """
-      match attribute $x;
-      """
-    Then uniquely identify answer concepts
-      | x                                |
-      | label:name                       |
-      | label:email                      |
-      | label:start-date                 |
-      | label:employment-reference-code  |
-      | label:phone-nr                   |
-      | label:_private-name              |
-
-
   ################
   # ENTITY TYPES #
   ################

--- a/query/language/match.feature
+++ b/query/language/match.feature
@@ -5422,16 +5422,16 @@ Feature: TypeQL Match Clause
     Given transaction closes
 
     Given connection open schema transaction for database: typedb
-    Given typeql schema query; parsing fails
+    Given typeql schema query
       """
       define
-      entity _leading_connector_disallowed;
+      entity _leading_underscore_allowed;
       """
 
     Given typeql read query; parsing fails
       """
       match
-      entity $_leading_connector_disallowed;
+      entity $_leading_underscore_in_var_disallowed;
       """
 
     Given typeql schema query

--- a/query/language/match.feature
+++ b/query/language/match.feature
@@ -5437,6 +5437,8 @@ Feature: TypeQL Match Clause
     Given typeql schema query
       """
       define
+      relation _underscore-relation relates _underscore-role;
+      entity _leading_underscore_allowed plays _underscore-relation:_underscore-role;
       entity following_connectors-and-digits-1-2-3-allowed;
       """
     Given transaction commits
@@ -5446,4 +5448,22 @@ Feature: TypeQL Match Clause
       """
       match
       entity $following_connectors-and-digits-1-2-3-allowed;
+      """
+
+    Given get answers of typeql read query
+      """
+      match
+      $r isa _underscore-relation;
+      $r links (_underscore-relation:_underscore-role: $p);
+      """
+
+    Given get answers of typeql read query
+      """
+      with
+      fun _underscore-func($p: _leading_underscore_allowed) -> _leading_underscore_allowed:
+      match $p isa _leading_underscore_allowed;
+      return first $p;
+      match
+      $p isa _leading_underscore_allowed;
+      let $q = _underscore-func($p);
       """

--- a/query/language/match.feature
+++ b/query/language/match.feature
@@ -5453,8 +5453,7 @@ Feature: TypeQL Match Clause
     Given get answers of typeql read query
       """
       match
-      $r isa _underscore-relation;
-      $r links (_underscore-relation:_underscore-role: $p);
+      $r isa _underscore-relation (_underscore-role: $p), links (_underscore-role: $q);
       """
 
     Given get answers of typeql read query


### PR DESCRIPTION
## Usage and product changes

Update existing test to allow leading underscores in type labels.

## Implementation

