### PR TITLE
Update unbound variable messages

### DIFF
--- a/query/language/expression.feature
+++ b/query/language/expression.feature
@@ -40,7 +40,7 @@ Feature: TypeQL Query with Expressions
     Given transaction commits
 
     Given connection open read transaction for database: typedb
-    Then typeql read query; fails with a message containing: "Invalid query containing unbound concept variable v"
+    Then typeql read query; fails with a message containing: "Invalid query containing unbound concept variable 'v'"
     """
       match
         $x isa person, has age $a, has height $h;

--- a/query/language/expression.feature
+++ b/query/language/expression.feature
@@ -40,7 +40,7 @@ Feature: TypeQL Query with Expressions
     Given transaction commits
 
     Given connection open read transaction for database: typedb
-    Then typeql read query; fails with a message containing: "Invalid query containing unbound concept variable 'v'"
+    Then typeql read query; fails with a message containing: "The variable 'v' is required to be bound to a value before it's used"
     """
       match
         $x isa person, has age $a, has height $h;

--- a/query/language/optional.feature
+++ b/query/language/optional.feature
@@ -154,8 +154,6 @@ Feature: TypeQL Optional
 
 
   Scenario: an optional cannot be used within a disjunction
-    # TODO: Better error messages from core again
-    # Then  typeql read query; fails with a message containing: "cannot be re-used elsewhere as a locally-scoped variable"
     Then typeql read query; fails with a message containing: "is required to be bound to a value before it's used"
       """
       match $x isa person, has name "Frank";
@@ -196,8 +194,6 @@ Feature: TypeQL Optional
     Then uniquely identify answer concepts
       | x         | r1        | r2        |
       | key:ref:1 | key:ref:3 | key:ref:3 |
-    # TODO: Better error messages from core again
-    # Then typeql read query; fails with a message containing: "cannot be re-used elsewhere as a locally-scoped variable"
     Then typeql read query; fails with a message containing: "The variable 'y' is required to be bound to a value before it's used"
 
     """

--- a/query/language/variables.feature
+++ b/query/language/variables.feature
@@ -3,7 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #noinspection CucumberUndefinedStep
-Feature: TypeQL Define Query
+Feature: TypeQL Variable binding tests
   # Note: Most rules across stages are repeated in pipeline.feature
   Background: Open connection and create a simple extensible schema
     Given typedb starts
@@ -37,7 +37,7 @@ Feature: TypeQL Define Query
 
   Scenario: Variables are not available in subsequent stages if they are not selected by a select stage
     Given connection open read transaction for database: typedb
-    Then typeql read query; fails with a message containing: "Invalid query containing unbound concept variable 'x'"
+    Then typeql read query; fails with a message containing: "The variable 'x' is required to be bound to a value before it's used"
     """
     match
       let $x = 1;
@@ -50,7 +50,7 @@ Feature: TypeQL Define Query
 
   Scenario: Variables are not available in subsequent stages if they are aggregated over by a reduce stage
     Given connection open read transaction for database: typedb
-    Then typeql read query; fails with a message containing: "Invalid query containing unbound concept variable 'x'"
+    Then typeql read query; fails with a message containing: "The variable 'x' is required to be bound to a value before it's used"
     """
     match
       let $x = 1;
@@ -114,7 +114,7 @@ Feature: TypeQL Define Query
       let $y = $x + 2;
     """
 
-    Then typeql read query; fails with a message containing: "Invalid query containing unbound concept variable 'x'"
+    Then typeql read query; fails with a message containing: "The variable 'x' is required to be bound to a value before it's used"
     """
     match
       { let $x = 1; let $a = 100; } or { let $z = 11; let $a = 100; };
@@ -192,7 +192,7 @@ Feature: TypeQL Define Query
       | b                |
       | value:integer:12 |
 
-    Then typeql read query; fails with a message containing: "Invalid query containing unbound concept variable 'x'"
+    Then typeql read query; fails with a message containing: "The variable 'x' is required to be bound to a value before it's used"
     """
     match
       let $a = 10;

--- a/query/language/variables.feature
+++ b/query/language/variables.feature
@@ -22,15 +22,6 @@ Feature: TypeQL Define Query
       """
     Given transaction commits
 
-#
-#    Given connection open write transaction for database: typedb
-#    When typeql write query
-#    """
-#    insert
-#      $_ isa number 1;
-#      $_ isa number 11;
-#    """
-#    Then transaction commits
 
   Scenario: Variables are available in the next stage
     Given connection open read transaction for database: typedb
@@ -46,7 +37,7 @@ Feature: TypeQL Define Query
 
   Scenario: Variables are not available in subsequent stages if they are not selected by a select stage
     Given connection open read transaction for database: typedb
-    Then typeql read query; fails with a message containing: "Invalid query containing unbound concept variable x"
+    Then typeql read query; fails with a message containing: "Invalid query containing unbound concept variable 'x'"
     """
     match
       let $x = 1;
@@ -59,7 +50,7 @@ Feature: TypeQL Define Query
 
   Scenario: Variables are not available in subsequent stages if they are aggregated over by a reduce stage
     Given connection open read transaction for database: typedb
-    Then typeql read query; fails with a message containing: "Invalid query containing unbound concept variable x"
+    Then typeql read query; fails with a message containing: "Invalid query containing unbound concept variable 'x'"
     """
     match
       let $x = 1;
@@ -123,7 +114,7 @@ Feature: TypeQL Define Query
       let $y = $x + 2;
     """
 
-    Then typeql read query; fails with a message containing: "Invalid query containing unbound concept variable x"
+    Then typeql read query; fails with a message containing: "Invalid query containing unbound concept variable 'x'"
     """
     match
       { let $x = 1; let $a = 100; } or { let $z = 11; let $a = 100; };
@@ -201,7 +192,7 @@ Feature: TypeQL Define Query
       | b                |
       | value:integer:12 |
 
-    Then typeql read query; fails with a message containing: "Invalid query containing unbound concept variable x"
+    Then typeql read query; fails with a message containing: "Invalid query containing unbound concept variable 'x'"
     """
     match
       let $a = 10;


### PR DESCRIPTION
Doing: I'm re-ordering core validation so the requiredness comes before the category-unboundedness.

## Usage and product changes
Updates the unbound concept variable message with quotes, cleans up.

