### PR TITLE
Update annotations test to reflect skipping unreferenced variables in blocks

### DIFF
--- a/driver/query.feature
+++ b/driver/query.feature
@@ -1234,13 +1234,13 @@ Feature: Driver Query
       ),
       Select(),
       Delete(
-        And({ $n: instance([name]), $x: instance([person]) }, [])
+        And({ $n: instance([name]) }, [])
       ),
       Insert(
         And({ $_: instance([name]), $x: instance([person]) }, [])
       ),
       Match(
-        And({ $n1:instance([name]), $x: instance([person]) }, [])
+        And({ $n1:instance([name]) }, [])
       ),
       Put(
         And({ $n1:instance([name]), $x: instance([person]) }, [])

--- a/query/analyze/annotations.feature
+++ b/query/analyze/annotations.feature
@@ -242,9 +242,9 @@ Feature: Analyzed query annotations
         )
       ),
       Select(),
-      Delete(And({ $n: instance([name]), $x: instance([person]) }, [])),
+      Delete(And({ $n: instance([name]) }, [])),
       Insert(And({ $_: instance([name]), $x: instance([person]) }, [])),
-      Match(And({ $n1:instance([name]), $x: instance([person]) }, [])),
+      Match(And({ $n1:instance([name]) }, [])),
       Put(And({ $n1:instance([name]), $x: instance([person]) }, []))
     ])
     """
@@ -450,6 +450,24 @@ Feature: Analyzed query annotations
         friends: List({
           name: [string]
         }),
+        ref: [integer]
+      }
+    """
+
+    # Skip a level
+    When get answers of typeql analyze
+    """
+      match
+        $p isa person, has ref $r;
+      match
+        let $x = 1.0;
+      fetch {
+        "ref": $r
+      };
+    """
+    Then analyzed fetch annotations are:
+    """
+      {
         ref: [integer]
       }
     """


### PR DESCRIPTION
## Usage and product changes
Update annotations test to reflect skipping unreferenced variables in blocks ( typedb/typedb#7810 )


