### PR TITLE
Add scenarios to verify database deletion is correctly combined with transaction lifetimes

### DIFF
--- a/connection/database.feature
+++ b/connection/database.feature
@@ -146,6 +146,13 @@ Feature: Connection Database
       define entity person;
       """
     Then connection delete database: typedb; fails
+    Then transaction rollbacks
+    Then transaction is open: true
+    Then connection delete database: typedb; fails
+    Then typeql schema query
+      """
+      define entity person;
+      """
     Then transaction commits
     Then connection delete database: typedb
     Then connection does not have database: typedb

--- a/connection/database.feature
+++ b/connection/database.feature
@@ -145,6 +145,21 @@ Feature: Connection Database
       """
       define entity person;
       """
+    Then connection delete database: typedb; fails
     Then transaction commits
     Then connection delete database: typedb
     Then connection does not have database: typedb
+
+  Scenario Outline: database can be deleted and recreated immediately after closing <type> transactions
+    When connection create database: typedb
+    When connection open <type> transaction for database: typedb
+    Then transaction closes
+    Then connection delete database: typedb
+    Then connection does not have database: typedb
+    When connection create database: typedb
+    Then connection has database: typedb
+    Examples:
+      | type   |
+      | schema |
+      | write  |
+      | read   |


### PR DESCRIPTION
## Usage and product changes
Extend database-deletion-related scenarios to verify that:
- database with an open transaction cannot be deleted even after rollbacks and queries, unless it's committed or closed
- database can be deleted right after the transaction was closed (covers https://github.com/typedb/typedb/pull/7863 )



## Implementation

