### PR TITLE
Add BDD scenarios for 'vector' value type

### DIFF
--- a/query/language/define.feature
+++ b/query/language/define.feature
@@ -1083,7 +1083,7 @@ Feature: TypeQL Define Query
   Scenario: an attribute type can be defined with a fixed-size vector value type
     When typeql schema query
       """
-      define attribute embedding value vector(3, f8);
+      define attribute embedding value vector(3, "float32");
       """
     Then transaction commits
 
@@ -1092,7 +1092,7 @@ Feature: TypeQL Define Query
     When typeql schema query
       """
       define
-      attribute embedding value vector(3, f8);
+      attribute embedding value vector(3, "float32");
       entity document owns embedding;
       """
     Then transaction commits
@@ -1110,7 +1110,7 @@ Feature: TypeQL Define Query
   Scenario: defining an embedding value type with a non-integer length errors
     Then typeql schema query; fails
       """
-      define attribute embedding value vector(abc, f8);
+      define attribute embedding value vector(abc, "float32");
       """
 
 

--- a/query/language/define.feature
+++ b/query/language/define.feature
@@ -1110,7 +1110,7 @@ Feature: TypeQL Define Query
   Scenario: defining an embedding value type with a non-integer length errors
     Then typeql schema query; fails
       """
-      define attribute embedding value vector(abc, "float32");
+      define attribute embedding value vector(3.0, "float32");
       """
 
 

--- a/query/language/define.feature
+++ b/query/language/define.feature
@@ -1121,6 +1121,13 @@ Feature: TypeQL Define Query
       """
 
 
+  Scenario: defining an embedding value type with a negative length errors
+    Then typeql schema query; fails
+      """
+      define attribute embedding value vector(-3, "float32");
+      """
+
+
   Scenario: new attribute type declaration should contain kind
     Then typeql schema query; fails
       """

--- a/query/language/define.feature
+++ b/query/language/define.feature
@@ -1080,6 +1080,49 @@ Feature: TypeQL Define Query
       | duration    | procedure-duration |
 
 
+  Scenario: an attribute type can be defined with a fixed-size double-array value type
+    When typeql schema query
+      """
+      define attribute embedding value double[3];
+      """
+    Then transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match
+        $x label embedding;
+        attribute $x;
+      """
+    Then answer size is: 1
+
+
+  Scenario: an entity type can own an embedding attribute type
+    When typeql schema query
+      """
+      define
+      attribute embedding value double[3];
+      entity document owns embedding;
+      """
+    Then transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match
+        $x label document, owns $e;
+        $e label embedding;
+      """
+    Then answer size is: 1
+
+
+  Scenario: defining an embedding value type with a non-integer length errors
+    Then typeql schema query; fails
+      """
+      define attribute embedding value double[abc];
+      """
+
+
   Scenario: new attribute type declaration should contain kind
     Then typeql schema query; fails
       """

--- a/query/language/define.feature
+++ b/query/language/define.feature
@@ -1080,10 +1080,10 @@ Feature: TypeQL Define Query
       | duration    | procedure-duration |
 
 
-  Scenario: an attribute type can be defined with a fixed-size double-array value type
+  Scenario: an attribute type can be defined with a fixed-size vector value type
     When typeql schema query
       """
-      define attribute embedding value double[3];
+      define attribute embedding value vector(3, f8);
       """
     Then transaction commits
 
@@ -1101,7 +1101,7 @@ Feature: TypeQL Define Query
     When typeql schema query
       """
       define
-      attribute embedding value double[3];
+      attribute embedding value vector(3, f8);
       entity document owns embedding;
       """
     Then transaction commits
@@ -1119,7 +1119,7 @@ Feature: TypeQL Define Query
   Scenario: defining an embedding value type with a non-integer length errors
     Then typeql schema query; fails
       """
-      define attribute embedding value double[abc];
+      define attribute embedding value vector(abc, f8);
       """
 
 

--- a/query/language/define.feature
+++ b/query/language/define.feature
@@ -1114,6 +1114,13 @@ Feature: TypeQL Define Query
       """
 
 
+  Scenario: defining an embedding value type with an invalid encoding errors
+    Then typeql schema query; fails
+      """
+      define attribute embedding value vector(3, "an-invalid-encoding");
+      """
+
+
   Scenario: new attribute type declaration should contain kind
     Then typeql schema query; fails
       """

--- a/query/language/define.feature
+++ b/query/language/define.feature
@@ -1087,15 +1087,6 @@ Feature: TypeQL Define Query
       """
     Then transaction commits
 
-    Given connection open read transaction for database: typedb
-    When get answers of typeql read query
-      """
-      match
-        $x label embedding;
-        attribute $x;
-      """
-    Then answer size is: 1
-
 
   Scenario: an entity type can own an embedding attribute type
     When typeql schema query

--- a/query/language/insert.feature
+++ b/query/language/insert.feature
@@ -2901,7 +2901,7 @@ Parker";
     Given typeql schema query
       """
       define
-      attribute embedding value double[3];
+      attribute embedding value vector(3, f8);
       entity document owns embedding;
       """
     Given transaction commits
@@ -2929,7 +2929,7 @@ Parker";
     Given typeql schema query
       """
       define
-      attribute embedding value double[3];
+      attribute embedding value vector(3, f8);
       entity document owns embedding;
       """
     Given transaction commits

--- a/query/language/insert.feature
+++ b/query/language/insert.feature
@@ -2901,7 +2901,7 @@ Parker";
     Given typeql schema query
       """
       define
-      attribute embedding value vector(3, f8);
+      attribute embedding value vector(3, "float32");
       entity document owns embedding;
       """
     Given transaction commits
@@ -2911,7 +2911,7 @@ Parker";
       """
       insert
       $x isa document,
-        has embedding [0.1, 0.2, 0.3];
+        has embedding vector([0.1, 0.2, 0.3], "float32");
       """
     Then transaction commits
 
@@ -2929,7 +2929,7 @@ Parker";
     Given typeql schema query
       """
       define
-      attribute embedding value vector(3, f8);
+      attribute embedding value vector(3, "float32");
       entity document owns embedding;
       """
     Given transaction commits
@@ -2939,5 +2939,5 @@ Parker";
       """
       insert
       $x isa document,
-        has embedding [0.1, 0.2];
+        has embedding vector([0.1, 0.2], "float32");
       """

--- a/query/language/insert.feature
+++ b/query/language/insert.feature
@@ -2894,3 +2894,50 @@ Parker";
     Then uniquely identify answer concepts
       | p             | age         |
       | key:name:John | attr:age:32 |
+
+
+  Scenario: an embedding value can be inserted
+    Given connection open schema transaction for database: typedb
+    Given typeql schema query
+      """
+      define
+      attribute embedding value double[3];
+      entity document owns embedding;
+      """
+    Given transaction commits
+
+    Given connection open write transaction for database: typedb
+    When typeql write query
+      """
+      insert
+      $x isa document,
+        has embedding [0.1, 0.2, 0.3];
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match
+        $x isa document, has embedding $e;
+      """
+    Then answer size is: 1
+
+
+  Scenario: inserting an embedding whose length differs from the declared array size errors
+    Given connection open schema transaction for database: typedb
+    Given typeql schema query
+      """
+      define
+      attribute embedding value double[3];
+      entity document owns embedding;
+      """
+    Given transaction commits
+
+    Given connection open write transaction for database: typedb
+    Then typeql write query; fails
+      """
+      insert
+      $x isa document,
+        has embedding [0.1, 0.2];
+      """

--- a/query/language/match.feature
+++ b/query/language/match.feature
@@ -5632,7 +5632,7 @@ Feature: TypeQL Match Clause
       """
 
 
-  Scenario: documents can be ranked and filtered by cosine similarity to a query embedding
+  Scenario: documents can be retrieved by indexed cosine similarity search on an embedding attribute
     Given typeql schema query
       """
       define
@@ -5654,15 +5654,13 @@ Feature: TypeQL Match Clause
     When get answers of typeql read query
       """
       match
+        let $e in cosine_similarity_search(embedding, vector([1.0, 0.0, 0.0], "float32"), 0.8);
         $doc isa document, has name $name, has embedding $e;
-        let $score = cosine_similarity($e, [1.0, 0.0, 0.0]);
-        $score >= 0.8;
       select
-        $name, $score;
-      sort $score desc;
+        $name;
       limit 10;
       """
     Then answer size is: 1
     Then uniquely identify answer concepts
-      | name                | score            |
-      | value:string:"near" | value:double:1.0 |
+      | name           |
+      | attr:name:near |

--- a/query/language/match.feature
+++ b/query/language/match.feature
@@ -5636,7 +5636,7 @@ Feature: TypeQL Match Clause
     Given typeql schema query
       """
       define
-      attribute embedding value double[3];
+      attribute embedding value vector(3, f8);
       entity document owns name @key, owns embedding;
       """
     Given transaction commits

--- a/query/language/match.feature
+++ b/query/language/match.feature
@@ -5636,7 +5636,7 @@ Feature: TypeQL Match Clause
     Given typeql schema query
       """
       define
-      attribute embedding value vector(3, f8);
+      attribute embedding value vector(3, "float32");
       entity document owns name @key, owns embedding;
       """
     Given transaction commits
@@ -5645,8 +5645,8 @@ Feature: TypeQL Match Clause
     When typeql write query
       """
       insert
-      $near isa document, has name "near", has embedding [1.0, 0.0, 0.0];
-      $far isa document, has name "far", has embedding [0.0, 1.0, 0.0];
+      $near isa document, has name "near", has embedding vector([1.0, 0.0, 0.0], "float32");
+      $far isa document, has name "far", has embedding vector([0.0, 1.0, 0.0], "float32");
       """
     Then transaction commits
 

--- a/query/language/match.feature
+++ b/query/language/match.feature
@@ -5630,3 +5630,39 @@ Feature: TypeQL Match Clause
       $p isa _leading_underscore_allowed;
       let $q = _underscore-func($p);
       """
+
+
+  Scenario: documents can be ranked and filtered by cosine similarity to a query embedding
+    Given typeql schema query
+      """
+      define
+      attribute embedding value double[3];
+      entity document owns name @key, owns embedding;
+      """
+    Given transaction commits
+
+    Given connection open write transaction for database: typedb
+    When typeql write query
+      """
+      insert
+      $near isa document, has name "near", has embedding [1.0, 0.0, 0.0];
+      $far isa document, has name "far", has embedding [0.0, 1.0, 0.0];
+      """
+    Then transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match
+        $doc isa document, has name $name, has embedding $e;
+        let $score = cosine_similarity($e, [1.0, 0.0, 0.0]);
+        $score >= 0.8;
+      select
+        $name, $score;
+      sort $score desc;
+      limit 10;
+      """
+    Then answer size is: 1
+    Then uniquely identify answer concepts
+      | name                | score            |
+      | value:string:"near" | value:double:1.0 |


### PR DESCRIPTION
## Usage and product changes

Adds BDD scenarios for 'vector' value type and cosine-similarity vector search operation.

## Implementation

- Added defining double array scenarios in `define.feature`
- Added inserting double array scenarios in `insert.feature`
- Added match scenario in `match.feature`